### PR TITLE
GitHub statistics

### DIFF
--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -2,11 +2,10 @@
 # Licensed under the MIT License.
 
 import sys
-sys.path.append('..')
-sys.path.append('../..')
-sys.path.append('/data/home/recocat/cicd/21/s/scripts')
-sys.path.append('/data/home/recocat/cicd/21/s')
-print(sys.path)
+# Need to append a full path instead of relative path.
+# This seems to be an issue from Azure DevOps command line task.
+# NOTE this does not affect running directly in the shell.
+sys.path.append('cicdworkdir/scripts')
 import os
 import argparse
 import traceback

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -6,8 +6,7 @@ import os
 # Need to append a full path instead of relative path.
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
-# sys.path.append('cicdworkdir')
-sys.path.append(os.path.join(os.getcwd(), 'scripts'))
+sys.path.append(os.getcwd())
 print(sys.path)
 import os
 import argparse

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -4,6 +4,8 @@
 import sys
 sys.path.append('..')
 sys.path.append('../..')
+sys.path.append('/data/home/recocat/cicd/21/s/scripts')
+sys.path.append('/data/home/recocat/cicd/21/s')
 print(sys.path)
 import os
 import argparse

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -7,8 +7,6 @@ import os
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
 sys.path.append(os.getcwd())
-print(sys.path)
-import os
 import argparse
 import traceback
 import logging

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -4,6 +4,7 @@
 import sys
 sys.path.append('..')
 sys.path.append('../..')
+print(sys.path)
 import os
 import argparse
 import traceback

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -6,6 +6,8 @@ import sys
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
 sys.path.append('cicdworkdir')
+sys.path.append('cicdworkdir/scripts')
+print(sys.path)
 import os
 import argparse
 import traceback

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -1,6 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import sys
+sys.path.append('..')
+sys.path.append('../..')
 import os
 import argparse
 import traceback

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -5,7 +5,7 @@ import sys
 # Need to append a full path instead of relative path.
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
-sys.path.append('cicdworkdir/scripts')
+sys.path.append('cicdworkdir')
 import os
 import argparse
 import traceback

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -7,7 +7,7 @@ import os
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
 # sys.path.append('cicdworkdir')
-sys.path.append(os.path.join(os.getcwd() + 'scripts'))
+sys.path.append(os.path.join(os.getcwd(), 'scripts'))
 print(sys.path)
 import os
 import argparse

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -7,7 +7,7 @@ import os
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
 # sys.path.append('cicdworkdir')
-sys.path.append(sys.path.join(os.getcwd() + 'scripts'))
+sys.path.append(os.path.join(os.getcwd() + 'scripts'))
 print(sys.path)
 import os
 import argparse

--- a/scripts/repo_metrics/track_metrics.py
+++ b/scripts/repo_metrics/track_metrics.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 
 import sys
+import os
 # Need to append a full path instead of relative path.
 # This seems to be an issue from Azure DevOps command line task.
 # NOTE this does not affect running directly in the shell.
-sys.path.append('cicdworkdir')
-sys.path.append('cicdworkdir/scripts')
+# sys.path.append('cicdworkdir')
+sys.path.append(sys.path.join(os.getcwd() + 'scripts'))
 print(sys.path)
 import os
 import argparse


### PR DESCRIPTION
### Description
Updates of scripts to generate Github stats.

### Motivation and Context
To have an idea about the stats change of the repo.

Note because of some issues in Azure DevOps command line task, the Python that imports custom module does not work well in terms of module path. One needs to add the full system path (not the relative ones like `..` or `../..`) to make sure the custom module / script is visible. 

Running the script directly from shell with `python` executable does not have the problem. 

### Releated Issues
#254 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



