### PR TITLE
Fix pyspark tests

### DIFF
--- a/notebooks/00_quick_start/als_pyspark_movielens.ipynb
+++ b/notebooks/00_quick_start/als_pyspark_movielens.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 20,
    "metadata": {
     "tags": [
      "parameters"
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,20 +209,21 @@
     "    regParam=0.05,\n",
     "    coldStartStrategy='drop',\n",
     "    nonnegative=True,\n",
+    "    seed=0,\n",
     "    **header\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Took 3.917855978012085 seconds for training.\n"
+      "Took 1.6378734111785889 seconds for training.\n"
      ]
     }
    ],
@@ -244,14 +245,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Took 10.53335952758789 seconds for prediction.\n"
+      "Took 7.481266021728516 seconds for prediction.\n"
      ]
     }
    ],
@@ -284,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -294,26 +295,26 @@
       "+------+-------+----------+\n",
       "|UserId|MovieId|prediction|\n",
       "+------+-------+----------+\n",
-      "|     1|    587| 3.0995538|\n",
-      "|     1|    869| 2.6100688|\n",
-      "|     1|   1208| 3.0915143|\n",
-      "|     1|   1357| 2.8258212|\n",
-      "|     1|   1677| 3.1421807|\n",
-      "|     2|     80| 2.5341926|\n",
-      "|     2|    472| 2.8482668|\n",
-      "|     2|    582| 3.6573615|\n",
-      "|     2|    838| 3.1394384|\n",
-      "|     2|    975| 2.5914822|\n",
-      "|     2|   1260| 3.5353842|\n",
-      "|     2|   1381| 3.5996914|\n",
-      "|     2|   1530| 1.8448312|\n",
-      "|     3|     22|  3.364335|\n",
-      "|     3|     57| 3.1117475|\n",
-      "|     3|     89| 3.3679981|\n",
-      "|     3|    367|  3.418139|\n",
-      "|     3|   1091|  1.487646|\n",
-      "|     3|   1167| 1.3213345|\n",
-      "|     3|   1499| 3.6010625|\n",
+      "|     1|    587| 2.8883367|\n",
+      "|     1|    869| 3.1058621|\n",
+      "|     1|   1208|  3.340047|\n",
+      "|     1|   1357| 1.0552136|\n",
+      "|     1|   1677| 2.8296795|\n",
+      "|     2|     80|  2.558201|\n",
+      "|     2|    472|  2.369836|\n",
+      "|     2|    582| 3.7367828|\n",
+      "|     2|    838| 4.0375633|\n",
+      "|     2|    975| 2.9793942|\n",
+      "|     2|   1260| 2.8054411|\n",
+      "|     2|   1381|  4.042236|\n",
+      "|     2|   1530| 2.0050426|\n",
+      "|     3|     22| 3.6620386|\n",
+      "|     3|     57| 4.2958107|\n",
+      "|     3|     89| 3.7477994|\n",
+      "|     3|    367| 3.7359834|\n",
+      "|     3|   1091| 1.5272002|\n",
+      "|     3|   1167| 3.0535898|\n",
+      "|     3|   1499| 3.4373536|\n",
       "+------+-------+----------+\n",
       "only showing top 20 rows\n",
       "\n"
@@ -333,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -353,10 +354,10 @@
      "text": [
       "Model:\tALS\n",
       "Top K:\t10\n",
-      "MAP:\t0.005518\n",
-      "NDCG:\t0.047815\n",
-      "Precision@K:\t0.049575\n",
-      "Recall@K:\t0.017520\n"
+      "MAP:\t0.004810\n",
+      "NDCG:\t0.042890\n",
+      "Precision@K:\t0.047558\n",
+      "Recall@K:\t0.018512\n"
      ]
     }
    ],
@@ -378,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -388,26 +389,26 @@
       "+------+-------+------+---------+----------+\n",
       "|UserId|MovieId|Rating|Timestamp|prediction|\n",
       "+------+-------+------+---------+----------+\n",
-      "|   406|    148|   3.0|879540276| 2.4768562|\n",
-      "|    27|    148|   3.0|891543129| 2.3924854|\n",
-      "|   606|    148|   3.0|878150506| 3.7661505|\n",
-      "|   916|    148|   2.0|880843892| 2.3830526|\n",
-      "|   236|    148|   4.0|890117028| 1.9967049|\n",
-      "|   602|    148|   4.0|888638517| 4.0112243|\n",
-      "|   663|    148|   4.0|889492989| 3.0887232|\n",
-      "|   372|    148|   5.0|876869915|  4.360522|\n",
-      "|   190|    148|   4.0|891033742| 3.6157782|\n",
-      "|     1|    148|   2.0|875240799| 2.7489796|\n",
-      "|   297|    148|   3.0|875239619|  2.423687|\n",
-      "|   178|    148|   4.0|882824325| 3.8284626|\n",
-      "|   308|    148|   3.0|887740788|   3.16792|\n",
-      "|   923|    148|   4.0|880387474|  3.660116|\n",
-      "|    54|    148|   3.0|880937490|  4.021487|\n",
-      "|   430|    148|   2.0|877226047| 2.8338885|\n",
-      "|    92|    148|   2.0|877383934| 2.7825644|\n",
-      "|   447|    148|   4.0|878854729| 3.0947447|\n",
-      "|   374|    148|   4.0|880392992| 2.9112031|\n",
-      "|   891|    148|   5.0|891639793| 3.5267024|\n",
+      "|   406|    148|   3.0|879540276| 3.1060526|\n",
+      "|    27|    148|   3.0|891543129|  2.987563|\n",
+      "|   606|    148|   3.0|878150506| 3.5480995|\n",
+      "|   916|    148|   2.0|880843892| 2.4303973|\n",
+      "|   236|    148|   4.0|890117028| 2.3803542|\n",
+      "|   602|    148|   4.0|888638517|  4.034768|\n",
+      "|   663|    148|   4.0|889492989| 3.1775193|\n",
+      "|   372|    148|   5.0|876869915| 3.8502235|\n",
+      "|   190|    148|   4.0|891033742| 3.6281476|\n",
+      "|     1|    148|   2.0|875240799| 3.2900243|\n",
+      "|   297|    148|   3.0|875239619| 2.5826795|\n",
+      "|   178|    148|   4.0|882824325| 3.4037237|\n",
+      "|   308|    148|   3.0|887740788| 2.9986997|\n",
+      "|   923|    148|   4.0|880387474| 3.6832879|\n",
+      "|    54|    148|   3.0|880937490| 3.7294888|\n",
+      "|   430|    148|   2.0|877226047|  2.837641|\n",
+      "|    92|    148|   2.0|877383934| 2.7189898|\n",
+      "|   447|    148|   4.0|878854729| 3.2265146|\n",
+      "|   374|    148|   4.0|880392992| 2.5878148|\n",
+      "|   891|    148|   5.0|891639793| 3.3203146|\n",
       "+------+-------+------+---------+----------+\n",
       "only showing top 20 rows\n",
       "\n"
@@ -422,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -430,10 +431,10 @@
      "output_type": "stream",
      "text": [
       "Model:\tALS rating prediction\n",
-      "RMSE:\t0.95\n",
-      "MAE:\t0.740051\n",
-      "Explained variance:\t0.293822\n",
-      "R squared:\t0.288789\n"
+      "RMSE:\t0.950697\n",
+      "MAE:\t0.742400\n",
+      "Explained variance:\t0.285606\n",
+      "R squared:\t0.280812\n"
      ]
     }
    ],
@@ -442,7 +443,7 @@
     "                                    col_rating=\"Rating\", col_prediction=\"prediction\")\n",
     "\n",
     "print(\"Model:\\tALS rating prediction\",\n",
-    "      \"RMSE:\\t%.2f\" % rating_eval.rmse(),\n",
+    "      \"RMSE:\\t%f\" % rating_eval.rmse(),\n",
     "      \"MAE:\\t%f\" % rating_eval.mae(),\n",
     "      \"Explained variance:\\t%f\" % rating_eval.exp_var(),\n",
     "      \"R squared:\\t%f\" % rating_eval.rsquared(), sep='\\n')"
@@ -450,96 +451,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/papermill.record+json": {
-       "map": 0.005517846085316156
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "ndcg": 0.04781543827655758
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "precision": 0.04957537154989385
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "recall": 0.01752012853824661
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "rmse": 0.9454108568025573
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "mae": 0.740051167690803
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "exp_var": 0.29382225448616117
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "rsquared": 0.28878863917621156
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "train_time": 3.917855978012085
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "test_time": 10.53335952758789
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     }
@@ -559,21 +520,14 @@
     "    pm.record(\"train_time\", train_time)\n",
     "    pm.record(\"test_time\", test_time)\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python (scgraham_pyspark",
    "language": "python",
-   "name": "python3"
+   "name": "scgraham_pyspark"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/00_quick_start/als_pyspark_movielens.ipynb
+++ b/notebooks/00_quick_start/als_pyspark_movielens.ipynb
@@ -520,14 +520,14 @@
     "    pm.record(\"train_time\", train_time)\n",
     "    pm.record(\"test_time\", test_time)\n"
    ]
-  }, 
+  },
   {
-   "cell_type": "code", 
-   "execution_count": null, 
-   "metadata": {}, 
-   "outputs": [], 
-   "source": [] 
-  } 
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
  ],
  "metadata": {
   "celltoolbar": "Tags",

--- a/notebooks/00_quick_start/als_pyspark_movielens.ipynb
+++ b/notebooks/00_quick_start/als_pyspark_movielens.ipynb
@@ -521,13 +521,13 @@
     "    pm.record(\"test_time\", test_time)\n"
    ]
   }, 
-   { 
-    "cell_type": "code", 
-    "execution_count": null, 
-    "metadata": {}, 
-    "outputs": [], 
-    "source": [] 
-   } 
+  {
+   "cell_type": "code", 
+   "execution_count": null, 
+   "metadata": {}, 
+   "outputs": [], 
+   "source": [] 
+  } 
  ],
  "metadata": {
   "celltoolbar": "Tags",

--- a/notebooks/00_quick_start/als_pyspark_movielens.ipynb
+++ b/notebooks/00_quick_start/als_pyspark_movielens.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "parameters"
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -161,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -245,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -285,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -379,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -451,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -520,14 +520,21 @@
     "    pm.record(\"train_time\", train_time)\n",
     "    pm.record(\"test_time\", test_time)\n"
    ]
-  }
+  }, 
+   { 
+    "cell_type": "code", 
+    "execution_count": null, 
+    "metadata": {}, 
+    "outputs": [], 
+    "source": [] 
+   } 
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python (scgraham_pyspark",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "scgraham_pyspark"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tests/integration/test_notebooks_pyspark.py
+++ b/tests/integration/test_notebooks_pyspark.py
@@ -1,50 +1,34 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import os
 import pytest
 import papermill as pm
 from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
+from reco_utils.common.spark_utils import start_or_get_spark
 
 
-TOL = 0.5
+TOL = 0.05
 
 
 @pytest.mark.spark
 @pytest.mark.integration
-@pytest.mark.parametrize(
-    "size, result_list",
-    [
-        ("1m", [0.02, 0.15, 0.14, 0.07, 0.95, 0.73, 0.28, 0.28]),
-        ("10m", [0.03, 0.15, 0.14, 0.09, 0.85, 0.65, 0.36, 0.36]),
-        ("20m", [0.03, 0.15, 0.14, 0.08, 0.84, 0.63, 0.37, 0.37]),
-    ],
-)
-def test_als_pyspark_integration(notebooks, size, result_list):
+def test_als_pyspark_integration(notebooks):
     notebook_path = notebooks["als_pyspark"]
     pm.execute_notebook(
         notebook_path,
         OUTPUT_NOTEBOOK,
         kernel_name=KERNEL_NAME,
-        parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE=size),
+        parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE="1m"),
     )
     nb = pm.read_notebook(OUTPUT_NOTEBOOK)
-    df = nb.dataframe
-    result_map = df.loc[df["name"] == "map", "value"].values[0]
-    assert result_map == pytest.approx(result_list[0], TOL)
-    result_ndcg = df.loc[df["name"] == "ndcg", "value"].values[0]
-    assert result_ndcg == pytest.approx(result_list[1], TOL)
-    result_precision = df.loc[df["name"] == "precision", "value"].values[0]
-    assert result_precision == pytest.approx(result_list[2], TOL)
-    result_recall = df.loc[df["name"] == "recall", "value"].values[0]
-    assert result_recall == pytest.approx(result_list[3], TOL)
+    results = nb.dataframe.set_index("name")["value"]
+    start_or_get_spark("ALS PySpark").stop()
 
-    result_rmse = df.loc[df["name"] == "rmse", "value"].values[0]
-    assert result_rmse == pytest.approx(result_list[4], TOL)
-    result_mae = df.loc[df["name"] == "mae", "value"].values[0]
-    assert result_mae == pytest.approx(result_list[5], TOL)
-    result_exp_var = df.loc[df["name"] == "exp_var", "value"].values[0]
-    assert result_exp_var == pytest.approx(result_list[6], TOL)
-    result_rsquared = df.loc[df["name"] == "rsquared", "value"].values[0]
-    assert result_rsquared == pytest.approx(result_list[7], TOL)
-
+    assert results["map"] == pytest.approx(0.002206, rel=TOL)
+    assert results["ndcg"] == pytest.approx(0.025820, rel=TOL)
+    assert results["precision"] == pytest.approx(0.032251, rel=TOL)
+    assert results["recall"] == pytest.approx(0.010390, rel=TOL)
+    assert results["rmse"] == pytest.approx(0.860059, rel=TOL)
+    assert results["mae"] == pytest.approx(0.680096, rel=TOL)
+    assert results["exp_var"] == pytest.approx(0.412285, rel=TOL)
+    assert results["rsquared"] == pytest.approx(0.406626, rel=TOL)

--- a/tests/smoke/test_notebooks_pyspark.py
+++ b/tests/smoke/test_notebooks_pyspark.py
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import os
 import pytest
 import papermill as pm
 from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
+from reco_utils.common.spark_utils import start_or_get_spark
 
 
-TOL = 0.1
+TOL = 0.05
 
 
 @pytest.mark.smoke
@@ -21,22 +21,14 @@ def test_als_pyspark_smoke(notebooks):
         parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE="100k"),
     )
     nb = pm.read_notebook(OUTPUT_NOTEBOOK)
-    df = nb.dataframe
-    result_map = df.loc[df["name"] == "map", "value"].values[0]
-    assert result_map == pytest.approx(0.004, TOL)
-    result_ndcg = df.loc[df["name"] == "ndcg", "value"].values[0]
-    assert result_ndcg == pytest.approx(0.044285, TOL)
-    result_precision = df.loc[df["name"] == "precision", "value"].values[0]
-    assert result_precision == pytest.approx(0.047240, TOL)
-    result_recall = df.loc[df["name"] == "recall", "value"].values[0]
-    assert result_recall == pytest.approx(0.016443, TOL)
+    results = nb.dataframe.set_index("name")["value"]
+    start_or_get_spark("ALS PySpark").stop()
 
-    result_rmse = df.loc[df["name"] == "rmse", "value"].values[0]
-    assert result_rmse == pytest.approx(0.95, TOL)
-    result_mae = df.loc[df["name"] == "mae", "value"].values[0]
-    assert result_mae == pytest.approx(0.744727, TOL)
-    result_exp_var = df.loc[df["name"] == "exp_var", "value"].values[0]
-    assert result_exp_var == pytest.approx(0.287247, TOL)
-    result_rsquared = df.loc[df["name"] == "rsquared", "value"].values[0]
-    assert result_rsquared == pytest.approx(0.281822, TOL)
-
+    assert results["map"] == pytest.approx(0.00481, rel=TOL)
+    assert results["ndcg"] == pytest.approx(0.04289, rel=TOL)
+    assert results["precision"] == pytest.approx(0.047558, rel=TOL)
+    assert results["recall"] == pytest.approx(0.018512, rel=TOL)
+    assert results["rmse"] == pytest.approx(0.950697, rel=TOL)
+    assert results["mae"] == pytest.approx(0.7424, rel=TOL)
+    assert results["exp_var"] == pytest.approx(0.285606, rel=TOL)
+    assert results["rsquared"] == pytest.approx(0.280812, rel=TOL)


### PR DESCRIPTION
### Description
- Updates to pyspark notebook 
  - set seed value for ALS
  - update displayed values for new seed
- Updates to smoke test for pyspark notebook
  - using updated values from above
- Updates to integration test for pyspark notebook
  - dropping 10m, and 20m tests, updating values based on seed used above


### Motivation and Context
Fix failing smoke / integration tests and nightly pyspark staging builds
This removes variability introduced during ALS training to make tests work better
Additionally it reduces the size of tests to ensure integration tests can complete in a timely fashion
Addresses #369 

### Releated Issues
Should replace #370 and #371 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.



