### PR TITLE
Address issues with data types and warnings in SAR.

### DIFF
--- a/notebooks/00_quick_start/sar_single_node_movielens.ipynb
+++ b/notebooks/00_quick_start/sar_single_node_movielens.ipynb
@@ -52,6 +52,7 @@
     "import time\n",
     "import os\n",
     "import itertools\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "import papermill as pm\n",
     "\n",
@@ -193,6 +194,9 @@
     "    size=MOVIELENS_DATA_SIZE,\n",
     "    header=['UserId','MovieId','Rating','Timestamp']\n",
     ")\n",
+    "\n",
+    "# Convert the float precision to 32-bit in order to reduce memory consumption \n",
+    "data.loc[:, 'Rating'] = data['Rating'].astype(np.float32)\n",
     "\n",
     "data.head()"
    ]

--- a/notebooks/02_model/sar_single_node_deep_dive.ipynb
+++ b/notebooks/02_model/sar_single_node_deep_dive.ipynb
@@ -95,6 +95,7 @@
     "\n",
     "import os\n",
     "import itertools\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "import papermill as pm\n",
     "\n",
@@ -229,6 +230,9 @@
     "    size=MOVIELENS_DATA_SIZE,\n",
     "    header=['UserId','MovieId','Rating','Timestamp']\n",
     ")\n",
+    "\n",
+    "# Convert the float precision to 32-bit in order to reduce memory consumption \n",
+    "data.loc[:, 'Rating'] = data['Rating'].astype(np.float32)\n",
     "\n",
     "data.head()"
    ]
@@ -606,9 +610,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3.6 (recommender)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "recommender"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/reco_utils/recommender/sar/__init__.py
+++ b/reco_utils/recommender/sar/__init__.py
@@ -23,6 +23,3 @@ HASHED_USERS = "hashedUsers"
 def _user_item_return_type():
     return str
 
-
-def _predict_column_type():
-    return float

--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -280,7 +280,7 @@ class SARSingleNode:
 
         # store training set index for future use during prediction
         # DO NOT USE .values as the warning message suggests
-        self.index = newdf.as_matrix([self._col_hashed_users, self._col_hashed_items])
+        self.index = newdf[[self._col_hashed_users, self._col_hashed_items]].values
 
         n_items = len(self.unique_items)
         n_users = len(self.unique_users)
@@ -418,9 +418,6 @@ class SARSingleNode:
         else:
             scores_dense = scores.todense()
 
-        # take the intersection between train test items and items we actually need
-        test[self._col_hashed_users] = test[self.col_user].map(self.user_map_dict)
-
         # Mask out items in the train set.  This only makes sense for some
         # problems (where a user wouldn't interact with an item more than once).
         if self.remove_seen:
@@ -514,10 +511,10 @@ class SARSingleNode:
             scores_dense = scores.todense()
 
         # take the intersection between train test items and items we actually need
-        test[self._col_hashed_users] = test[self.col_user].map(self.user_map_dict)
-        test[self._col_hashed_items] = test[self.col_item].map(self.item_map_dict)
+        test_col_hashed_users = test[self.col_user].map(self.user_map_dict)
+        test_col_hashed_items = test[self.col_item].map(self.item_map_dict)
 
-        test_index = test.as_matrix([self._col_hashed_users, self._col_hashed_items])
+        test_index = pd.concat([test_col_hashed_users, test_col_hashed_items], axis=1).values
         aset = set([tuple(x) for x in self.index])
         bset = set([tuple(x) for x in test_index])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def pandas_dummy(header):
     ratings_dict = {
         header["col_user"]: [1, 1, 1, 1, 2, 2, 2, 2, 2, 2],
         header["col_item"]: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        header["col_rating"]: [1, 2, 3, 4, 5, 1, 2, 3, 4, 5],
+        header["col_rating"]: [1.0, 2.0, 3.0, 4.0, 5.0, 1.0, 2.0, 3.0, 4.0, 5.0],
     }
     df = pd.DataFrame(ratings_dict)
     return df
@@ -101,7 +101,7 @@ def train_test_dummy_timestamp(pandas_dummy_timestamp):
 def demo_usage_data(header, sar_settings):
     # load the data
     data = pd.read_csv(sar_settings["FILE_DIR"] + "demoUsage.csv")
-    data["rating"] = pd.Series([1] * data.shape[0])
+    data["rating"] = pd.Series([1.0] * data.shape[0])
     data = data.rename(
         columns={
             "userId": header["col_user"],

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -106,7 +106,7 @@ def test_predict(
     assert isinstance(preds, pd.DataFrame)
     assert preds[header["col_user"]].dtype == object
     assert preds[header["col_item"]].dtype == object
-    assert preds[PREDICTION_COL].dtype == float
+    assert preds[PREDICTION_COL].dtype == trainset[header["col_rating"]].dtype
 
 
 """


### PR DESCRIPTION
### Description
Change the SAR code and related tests and notebooks as follows:
- accept only floating point types for rating column
- use this data type for all computations in the SAR code
- use float32 in the notebooks
- do not modify data frame inputs to fit(), recommend(), predict() 

### Related Issues
#372 #160 
The python warnings do not appear any more, except a "division by zero" (I leave this for the next PR, together with efficiencies in the similarity functions). 
With 32-bit precision the memory consumption decreased, especially in the case of Movielens20M (`fit()` requires 25GB max; `recommend_k_items()` grew OOM above 60GB). 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.



