### PR TITLE
Python ranking evaluation return 0 if there is no hit

### DIFF
--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -286,8 +286,6 @@ def _merge_ranking_true_pred(
         rating_true_new, df_rating_pred, how="inner", on=[col_user, col_item]
     )[[col_user, col_item, "ranking"]]
 
-    assert df_hit.shape[0] > 0
-
     return rating_true_new, df_hit, n_users
 
 
@@ -336,6 +334,9 @@ def precision_at_k(
         k,
         threshold,
     )
+
+    if df_hit.shape[0] == 0:
+        return 0.0
 
     df_count_hit = (
         df_hit.groupby(col_user)
@@ -388,6 +389,9 @@ def recall_at_k(
         k,
         threshold,
     )
+
+    if df_hit.shape[0] == 0:
+        return 0.0
 
     df_count_hit = (
         df_hit.groupby(col_user)
@@ -450,6 +454,9 @@ def ndcg_at_k(
         k,
         threshold,
     )
+
+    if df_hit.shape[0] == 0:
+        return 0.0
 
     # Calculate gain for hit items.
     df_dcg = df_hit.sort_values([col_user, "ranking"])
@@ -528,6 +535,9 @@ def map_at_k(
         k,
         threshold,
     )
+
+    if df_hit.shape[0] == 0:
+        return 0.0
 
     # Calculate inverse of rank of items for each user, use the inverse ranks to penalize
     # precision,

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -70,11 +70,39 @@ def python_data():
             ],
         }
     )
-    return rating_true, rating_pred
+    rating_nohit = pd.DataFrame(
+        {
+            "userID": [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            "itemID": [100] * rating_pred.shape[0],
+            "prediction": [
+                14,
+                13,
+                12,
+                14,
+                13,
+                12,
+                11,
+                10,
+                14,
+                13,
+                12,
+                11,
+                10,
+                9,
+                8,
+                7,
+                6,
+                5,
+            ],
+        }
+
+    )
+
+    return rating_true, rating_pred, rating_nohit
 
 
 def test_python_rmse(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, _ = python_data
     assert (
         rmse(rating_true=rating_true, rating_pred=rating_true, col_prediction="rating")
         == 0
@@ -83,7 +111,7 @@ def test_python_rmse(python_data, target_metrics):
 
 
 def test_python_mae(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, _ = python_data
     assert (
         mae(rating_true=rating_true, rating_pred=rating_true, col_prediction="rating")
         == 0
@@ -92,7 +120,7 @@ def test_python_mae(python_data, target_metrics):
 
 
 def test_python_rsquared(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, _ = python_data
 
     assert rsquared(
         rating_true=rating_true, rating_pred=rating_true, col_prediction="rating"
@@ -102,7 +130,7 @@ def test_python_rsquared(python_data, target_metrics):
 
 
 def test_python_exp_var(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, _ = python_data
 
     assert exp_var(
         rating_true=rating_true, rating_pred=rating_true, col_prediction="rating"
@@ -112,7 +140,8 @@ def test_python_exp_var(python_data, target_metrics):
 
 
 def test_python_ndcg_at_k(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, rating_nohit = python_data
+
     assert (
         ndcg_at_k(
             k=10,
@@ -122,11 +151,13 @@ def test_python_ndcg_at_k(python_data, target_metrics):
         )
         == 1
     )
+    assert ndcg_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert ndcg_at_k(rating_true, rating_pred, k=10) == target_metrics["ndcg"]
 
 
 def test_python_map_at_k(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, rating_nohit = python_data
+
     assert (
         map_at_k(
             k=10,
@@ -136,11 +167,13 @@ def test_python_map_at_k(python_data, target_metrics):
         )
         == 1
     )
+    assert map_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert map_at_k(rating_true, rating_pred, k=10) == target_metrics["map"]
 
 
 def test_python_precision(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, rating_nohit = python_data
+
     assert (
         precision_at_k(
             k=10,
@@ -150,19 +183,22 @@ def test_python_precision(python_data, target_metrics):
         )
         == 0.6
     )
+    assert precision_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert precision_at_k(rating_true, rating_pred, k=10) == target_metrics["precision"]
 
 
 def test_python_recall(python_data, target_metrics):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, rating_nohit = python_data
+
     assert recall_at_k(
         k=10, rating_true=rating_true, rating_pred=rating_true, col_prediction="rating"
     ) == pytest.approx(1, 0.1)
+    assert recall_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert recall_at_k(rating_true, rating_pred, k=10) == target_metrics["recall"]
 
 
 def test_python_errors(python_data):
-    rating_true, rating_pred = python_data
+    rating_true, rating_pred, _ = python_data
 
     with pytest.raises(ValueError):
         rmse(rating_true, rating_true, col_user="not_user")


### PR DESCRIPTION
### Description
Instead of an assertion error, the ranking evaluator should return 0.

### Motivation and Context
This is useful if there is no hit in the recommendation and ground truth. For example, if there is someone building a 'I'm feeling lucky' recommender (k=1), then no hit can happen for the top-1 reco results.

### Releated Issues
#410 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING).
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.



