### PR TITLE
add additional packages required by fastai

### DIFF
--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -108,7 +108,8 @@ ${pyspark}- pyarrow>=0.8.0
 ${gpu}  - numba>=0.38.1 
   - gitpython>=2.1.8
   - pydocumentdb>=2.3.3
-  - azureml-core>=0.1.74
+${gpu}  - nvidia-ml-py3>=7.352.0
+  - dataclasses>=0.6
 EOM
 
 echo "Conda file generated: " $CONDA_FILE

--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -108,7 +108,7 @@ ${pyspark}- pyarrow>=0.8.0
 ${gpu}  - numba>=0.38.1 
   - gitpython>=2.1.8
   - pydocumentdb>=2.3.3
-${gpu}  - nvidia-ml-py3>=7.352.0
+  - nvidia-ml-py3>=7.352.0
   - dataclasses>=0.6
 EOM
 

--- a/tests/smoke/test_notebooks_gpu.py
+++ b/tests/smoke/test_notebooks_gpu.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import pytest
+from reco_utils.common.gpu_utils import get_number_gpus
+import papermill as pm
+from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
+
+TOL = 0.05
+
+@pytest.mark.smoke
+@pytest.mark.gpu
+def test_fastai(notebooks):
+    assert get_number_gpus() >= 1
+
+    notebook_path = notebooks["fastai"]
+    pm.execute_notebook(notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME)
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        kernel_name=KERNEL_NAME,
+        parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE="100k"),
+    )
+    results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
+
+    assert results["rmse"] == pytest.approx(0.912115, TOL)
+    assert results["mae"] == pytest.approx(0.723051, TOL)
+    assert results["rsquared"] == pytest.approx(0.356302, TOL)
+    assert results["exp_var"] == pytest.approx(0.357081, TOL)
+    assert results["map"] == pytest.approx(0.021485, TOL)
+    assert results["ndcg"] == pytest.approx(0.137494, TOL)
+    assert results["precision"] == pytest.approx(0.124284, TOL)
+    assert results["recall"] == pytest.approx(0.045587, TOL)
+

--- a/tests/smoke/test_notebooks_python.py
+++ b/tests/smoke/test_notebooks_python.py
@@ -47,23 +47,3 @@ def test_baseline_deep_dive_smoke(notebooks):
     assert results["precision"] == pytest.approx(0.223754, TOL)
     assert results["recall"] == pytest.approx(0.108826, TOL)
 
-@pytest.mark.smoke
-def test_fastai(notebooks):
-    notebook_path = notebooks["fastai"]
-    pm.execute_notebook(notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME)
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        kernel_name=KERNEL_NAME,
-        parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE="100k"),
-    )
-    results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
-
-    assert results["rmse"] == pytest.approx(0.912115, TOL)
-    assert results["mae"] == pytest.approx(0.723051, TOL)
-    assert results["rsquared"] == pytest.approx(0.356302, TOL)
-    assert results["exp_var"] == pytest.approx(0.357081, TOL)
-    assert results["map"] == pytest.approx(0.021485, TOL)
-    assert results["ndcg"] == pytest.approx(0.137494, TOL)
-    assert results["precision"] == pytest.approx(0.124284, TOL)
-    assert results["recall"] == pytest.approx(0.045587, TOL)

--- a/tests/smoke/test_template_gpu.py
+++ b/tests/smoke/test_template_gpu.py
@@ -3,10 +3,37 @@
 
 import pytest
 from reco_utils.common.gpu_utils import get_number_gpus
+import papermill as pm
+from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
 
+
+TOL = 0.05
 
 @pytest.mark.smoke
 @pytest.mark.gpu
 def test_gpu_vm():
     assert get_number_gpus() >= 1
+
+
+@pytest.mark.smoke
+@pytest.mark.gpu
+def test_fastai(notebooks):
+    notebook_path = notebooks["fastai"]
+    pm.execute_notebook(notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME)
+    pm.execute_notebook(
+        notebook_path,
+        OUTPUT_NOTEBOOK,
+        kernel_name=KERNEL_NAME,
+        parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE="100k"),
+    )
+    results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
+
+    assert results["rmse"] == pytest.approx(0.912115, TOL)
+    assert results["mae"] == pytest.approx(0.723051, TOL)
+    assert results["rsquared"] == pytest.approx(0.356302, TOL)
+    assert results["exp_var"] == pytest.approx(0.357081, TOL)
+    assert results["map"] == pytest.approx(0.021485, TOL)
+    assert results["ndcg"] == pytest.approx(0.137494, TOL)
+    assert results["precision"] == pytest.approx(0.124284, TOL)
+    assert results["recall"] == pytest.approx(0.045587, TOL)
 

--- a/tests/smoke/test_template_gpu.py
+++ b/tests/smoke/test_template_gpu.py
@@ -3,37 +3,11 @@
 
 import pytest
 from reco_utils.common.gpu_utils import get_number_gpus
-import papermill as pm
-from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
 
-
-TOL = 0.05
 
 @pytest.mark.smoke
 @pytest.mark.gpu
 def test_gpu_vm():
     assert get_number_gpus() >= 1
 
-
-@pytest.mark.smoke
-@pytest.mark.gpu
-def test_fastai(notebooks):
-    notebook_path = notebooks["fastai"]
-    pm.execute_notebook(notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME)
-    pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        kernel_name=KERNEL_NAME,
-        parameters=dict(TOP_K=10, MOVIELENS_DATA_SIZE="100k"),
-    )
-    results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
-
-    assert results["rmse"] == pytest.approx(0.912115, TOL)
-    assert results["mae"] == pytest.approx(0.723051, TOL)
-    assert results["rsquared"] == pytest.approx(0.356302, TOL)
-    assert results["exp_var"] == pytest.approx(0.357081, TOL)
-    assert results["map"] == pytest.approx(0.021485, TOL)
-    assert results["ndcg"] == pytest.approx(0.137494, TOL)
-    assert results["precision"] == pytest.approx(0.124284, TOL)
-    assert results["recall"] == pytest.approx(0.045587, TOL)
 

--- a/tests/smoke/test_template_gpu.py
+++ b/tests/smoke/test_template_gpu.py
@@ -10,4 +10,3 @@ from reco_utils.common.gpu_utils import get_number_gpus
 def test_gpu_vm():
     assert get_number_gpus() >= 1
 
-

--- a/tests/unit/test_notebooks_gpu.py
+++ b/tests/unit/test_notebooks_gpu.py
@@ -3,9 +3,20 @@
 
 import pytest
 from reco_utils.common.gpu_utils import get_number_gpus
-
+from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
+import papermill as pm
 
 @pytest.mark.notebooks
 @pytest.mark.gpu
 def test_gpu_vm():
     assert get_number_gpus() >= 1
+
+
+@pytest.mark.notebooks
+@pytest.mark.gpu
+def test_fastai(notebooks):
+    assert get_number_gpus() >= 1
+
+    notebook_path = notebooks["fastai"]
+    print('running fastai unit test')
+    pm.execute_notebook(notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME)


### PR DESCRIPTION
### Description
Fastai requires dataclasses to be pip installed if built on python < 3.7

### Motivation and Context
fixes fastai part of https://github.com/Microsoft/Recommenders/issues/434

### Releated Issues


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING).
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
- I ran nightly tests on the change: https://msdata.visualstudio.com/AlgorithmsAndDataScience/_build/results?buildId=2201874 



