### PR TITLE
Parameter to control pyspark version in conda

### DIFF
--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -91,8 +91,6 @@ fi
 # $ python -m ipykernel install --user --name my_env_name --display-name "Python (my_env_name)"
 #
 
-name: recommenders
-
 channels:
 - conda-forge
 - pytorch

--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -9,7 +9,7 @@
 # $ sh generate_conda_file.sh --pyspark
 # For generating a conda file for running python gpu and pyspark:
 # $ sh generate_conda_file.sh --gpu --pyspark
-# For generating a conda file for running python gpu and pyspark a particular version of spark:
+# For generating a conda file for running python gpu and pyspark with a particular version:
 # $ sh generate_conda_file.sh --gpu --pyspark-version 2.4.0
 #
 
@@ -32,6 +32,8 @@ pyspark="#"
 # flags to detect if both CPU and GPU are specified
 gpu_flag=false
 pyspark_flag=false
+
+# default version of pyspark if it is installed
 pyspark_version=2.3.1
 
 while [ ! $# -eq 0 ]

--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -40,7 +40,7 @@ do
 		--help)
 			echo "Please specify --gpu to install with GPU-support and"
 			echo "--pyspark to install with pySpark support"
-			echo "--pyspark-version X.Y.Z to install version X.Y.Z of pySpark (default 2.3.1)"
+			echo "--pyspark-version X.Y.Z to install version X.Y.Z of pySpark (default: $pyspark_version)"
 			exit
 			;;
 		--gpu)
@@ -61,6 +61,7 @@ do
 			pyspark_version=$2
 			if ! [[ $pyspark_version =~ ^[0-9]+([.][0-9]+){2}$ ]]; then
 				echo "Inappropriate version of pyspark passed:" $pyspark_version
+				echo "Version must be of format X.Y.Z"
 				exit 1
 			fi
 			shift

--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -9,6 +9,8 @@
 # $ sh generate_conda_file.sh --pyspark
 # For generating a conda file for running python gpu and pyspark:
 # $ sh generate_conda_file.sh --gpu --pyspark
+# For generating a conda file for running python gpu and pyspark a particular version of spark:
+# $ sh generate_conda_file.sh --gpu --pyspark-version 2.4.0
 #
 
 # first check if conda is installed
@@ -30,6 +32,7 @@ pyspark="#"
 # flags to detect if both CPU and GPU are specified
 gpu_flag=false
 pyspark_flag=false
+pyspark_version=2.3.1
 
 while [ ! $# -eq 0 ]
 do
@@ -37,6 +40,7 @@ do
 		--help)
 			echo "Please specify --gpu to install with GPU-support and"
 			echo "--pyspark to install with pySpark support"
+			echo "--pyspark-version X.Y.Z to install version X.Y.Z of pySpark (default 2.3.1)"
 			exit
 			;;
 		--gpu)
@@ -49,6 +53,17 @@ do
 			pyspark=""
 			CONDA_FILE="conda_pyspark.yaml"
 			pyspark_flag=true
+			;;			
+		--pyspark-version)
+			pyspark=""
+			CONDA_FILE="conda_pyspark.yaml"
+			pyspark_flag=true
+			pyspark_version=$2
+			if ! [[ $pyspark_version =~ ^[0-9]+([.][0-9]+){2}$ ]]; then
+				echo "Inappropriate version of pyspark passed:" $pyspark_version
+				exit 1
+			fi
+			shift
 			;;			
 		*)
 			echo $"Usage: $0 invalid argument $1 please run with --help for more information."
@@ -82,7 +97,7 @@ dependencies:
 - python==3.6.7
 - numpy>=1.13.3
 - dask>=0.17.1
-${pyspark}- pyspark==2.3.1
+${pyspark}- pyspark==${pyspark_version}
 - pymongo>=3.6.1
 - ipykernel>=4.6.1
 - ${tensorflow}==1.12.0

--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -88,6 +88,8 @@ fi
 # $ python -m ipykernel install --user --name my_env_name --display-name "Python (my_env_name)"
 #
 
+name: recommenders
+
 channels:
 - conda-forge
 - pytorch


### PR DESCRIPTION
### Description
Updated generate_conda_file.sh to take an optional argument to specify the version of spark to install.

### Motivation and Context

We are doing a lot of testing across different versions of spark due to databricks deprecation schedule. This should facilitate that while we also get databricks testing up and running.

https://github.com/Microsoft/Recommenders/issues/460

### Related Issues

https://github.com/Microsoft/Recommenders/issues/427

### Checklist:
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.
