### PR TITLE
[BUG] problem with azureml-sdk==1.0.15, rolling to 1.0.10

### DIFF
--- a/scripts/generate_conda_file.sh
+++ b/scripts/generate_conda_file.sh
@@ -124,7 +124,7 @@ ${pyspark}- pyarrow>=0.8.0
   - papermill>=0.15.0
   - black>=18.6b4
   - memory-profiler>=0.54.0
-  - azureml-sdk[notebooks,contrib]>=1.0.8
+  - azureml-sdk[notebooks,contrib]==1.0.10
 ${gpu}  - numba>=0.38.1 
   - gitpython>=2.1.8
   - pydocumentdb>=2.3.3


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

with azureml-sdk[contrib,notebooks]==1.0.15

```
  Could not find a version that satisfies the requirement azureml-contrib-run==1.0.15.*; extra == "contrib" (from azureml-sdk[contrib,notebooks]>=1.0.8->-r /data/home/recocat/notebooks/miguel/Recommenders/condaenv.pkI9LK.requirements.txt (line 12)) (from versions: 0.1.57, 0.1.58, 0.1.59, 0.1.65, 0.1.68, 0.1.74, 0.1.80, 1.0.2, 1.0.6, 1.0.8, 1.0.10)
No matching distribution found for azureml-contrib-run==1.0.15.*; extra == "contrib" (from azureml-sdk[contrib,notebooks]>=1.0.8->-r /data/home/recocat/notebooks/miguel/Recommenders/condaenv.pkI9LK.requirements.txt (line 12))

CondaValueError: pip returned an error
```
rolled back to 1.0.10. Also I fixed the version instead of using >=

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



