### PR TITLE
Added note to readme and ALS notebook when a pyspark environment is necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To setup on your local machine:
     ```
 6. Run the [SAR Python CPU Movielens](notebooks/00_quick_start/sar_python_cpu_movielens.ipynb) notebook under the 00_quick_start folder. Make sure to change the kernel to "Python (reco)".
 
-**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require a PySpark environment to run. Please follow the steps in the [setup guide](SETUP.md#dependencies-setup) to run these notebooks in a PySpark envionrment.
+**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require a PySpark environment to run. Please follow the steps in the [setup guide](SETUP.md#dependencies-setup) to run these notebooks in a PySpark environment.
 
 ## Notebooks
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To setup on your local machine:
     ```
 6. Run the [SAR Python CPU Movielens](notebooks/00_quick_start/sar_python_cpu_movielens.ipynb) notebook under the 00_quick_start folder. Make sure to change the kernel to "Python (reco)".
 
-**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require PySpark to run. Please follow the PySpark set up environment steps in the [setup guide](https://github.com/Microsoft/Recommenders/blob/master/SETUP.md#dependencies-setup) to run these notebooks.
+**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require PySpark to run. Please follow the PySpark set up environment steps in the [setup guide](/SETUP.md#dependencies-setup) to run these notebooks.
 
 ## Notebooks
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To setup on your local machine:
     ```
 6. Run the [SAR Python CPU Movielens](notebooks/00_quick_start/sar_python_cpu_movielens.ipynb) notebook under the 00_quick_start folder. Make sure to change the kernel to "Python (reco)".
 
-**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require PySpark to run. Please follow the PySpark set up environment steps in the [setup guide](/SETUP.md#dependencies-setup) to run these notebooks.
+**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require PySpark to run. Please follow the PySpark set up environment steps in the [setup guide](SETUP.md#dependencies-setup) to run these notebooks.
 
 ## Notebooks
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To setup on your local machine:
     ```
 6. Run the [SAR Python CPU Movielens](notebooks/00_quick_start/sar_python_cpu_movielens.ipynb) notebook under the 00_quick_start folder. Make sure to change the kernel to "Python (reco)".
 
-**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require PySpark to run. Please follow the PySpark set up environment steps in the [setup guide](SETUP.md#dependencies-setup) to run these notebooks.
+**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require a PySpark environment to run. Please follow the steps in the [setup guide](SETUP.md#dependencies-setup) to run these notebooks in a PySpark envionrment.
 
 ## Notebooks
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ To setup on your local machine:
     cd notebooks
     jupyter notebook
     ```
-5. Run the [SAR Python CPU Movielens](notebooks/00_quick_start/sar_python_cpu_movielens.ipynb) notebook under the 00_quick_start folder. Make sure to change the kernel to "Python (reco)".
+6. Run the [SAR Python CPU Movielens](notebooks/00_quick_start/sar_python_cpu_movielens.ipynb) notebook under the 00_quick_start folder. Make sure to change the kernel to "Python (reco)".
+
+**NOTE** - The [Alternating Least Squares (ALS)](notebooks/00_quick_start/als_movielens.ipynb) notebooks require PySpark to run. Please follow the PySpark set up environment steps in the [setup guide](https://github.com/Microsoft/Recommenders/blob/master/SETUP.md#dependencies-setup) to run these notebooks.
 
 ## Notebooks
 

--- a/notebooks/00_quick_start/als_movielens.ipynb
+++ b/notebooks/00_quick_start/als_movielens.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: This notebook requires a PySpark environment to run properly.. Please follow the steps in [Setup.md](https://github.com/heatherbshapiro/Recommenders/blob/heather_update_readme_for_pyspark/SETUP.md#dependencies-setup) to install the PySpark environment."
+    "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [Setup.md](https://github.com/heatherbshapiro/Recommenders/blob/heather_update_readme_for_pyspark/SETUP.md#dependencies-setup) to install the PySpark environment."
    ]
   },
   {

--- a/notebooks/00_quick_start/als_movielens.ipynb
+++ b/notebooks/00_quick_start/als_movielens.ipynb
@@ -13,11 +13,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Running ALS on MovieLens (pySpark)\n",
+    "# Running ALS on MovieLens (PySpark)\n",
     "\n",
     "Matrix factorization by [ALS](https://spark.apache.org/docs/latest/api/python/_modules/pyspark/ml/recommendation.html#ALS) (Alternating Least Squares) is a well known collaborative filtering algorithm.\n",
     "\n",
-    "This notebook provides an example of how to utilize and evaluate ALS pySpark ML (DataFrame-based API) implementation, meant for large-scale distributed datasets. We use a smaller dataset in this example to run ALS efficiently on multiple cores of a [Data Science Virtual Machine](https://azure.microsoft.com/en-gb/services/virtual-machines/data-science-virtual-machines/)."
+    "This notebook provides an example of how to utilize and evaluate ALS PySpark ML (DataFrame-based API) implementation, meant for large-scale distributed datasets. We use a smaller dataset in this example to run ALS efficiently on multiple cores of a [Data Science Virtual Machine](https://azure.microsoft.com/en-gb/services/virtual-machines/data-science-virtual-machines/)."
    ]
   },
   {

--- a/notebooks/00_quick_start/als_movielens.ipynb
+++ b/notebooks/00_quick_start/als_movielens.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [SETUP.md](https://github.com/heatherbshapiro/Recommenders/blob/heather_update_readme_for_pyspark/SETUP.md#dependencies-setup) to install the PySpark environment."
+    "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [SETUP.md](https://github.com/Microsoft/Recommenders/blob/master/SETUP.md#dependencies-setup) to install the PySpark environment."
    ]
   },
   {

--- a/notebooks/00_quick_start/als_movielens.ipynb
+++ b/notebooks/00_quick_start/als_movielens.ipynb
@@ -21,6 +21,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: This notebook requires a PySpark environment to run properly.. Please follow the steps in [Setup.md](https://github.com/heatherbshapiro/Recommenders/blob/heather_update_readme_for_pyspark/SETUP.md#dependencies-setup) to install the PySpark environment."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/notebooks/00_quick_start/als_movielens.ipynb
+++ b/notebooks/00_quick_start/als_movielens.ipynb
@@ -24,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [Setup.md](https://github.com/heatherbshapiro/Recommenders/blob/heather_update_readme_for_pyspark/SETUP.md#dependencies-setup) to install the PySpark environment."
+    "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [SETUP.md](https://github.com/heatherbshapiro/Recommenders/blob/heather_update_readme_for_pyspark/SETUP.md#dependencies-setup) to install the PySpark environment."
    ]
   },
   {

--- a/notebooks/02_model/als_deep_dive.ipynb
+++ b/notebooks/02_model/als_deep_dive.ipynb
@@ -79,6 +79,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [SETUP.md](https://github.com/Microsoft/Recommenders/blob/master/SETUP.md#dependencies-setup) to install the PySpark environment."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
### Description
Added notes to the getting started section of the Readme to explicitly call out that some of the quickstart notebooks require a different setup process for pyspark. Also added a note to the quickstart notebook itself to point out that a pyspark environment is required.

<!--- Why is this change required? What problem does it solve? -->
The ALS notebook is the first notebook in `00_quick_start` and users might not realize why it doesn't work with the basic setup from the readme. It is good to explicitly call this information out so users do not fall down the rabbit hole and get stuck.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.



