### PR TITLE
Checking input column dtypes for Python evaluators

### DIFF
--- a/notebooks/02_model/baseline_deep_dive.ipynb
+++ b/notebooks/02_model/baseline_deep_dive.ipynb
@@ -59,8 +59,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "System version: 3.6.0 | packaged by conda-forge | (default, Feb  9 2017, 14:54:13) [MSC v.1900 64 bit (AMD64)]\n",
-      "Pandas version: 0.23.4\n"
+      "System version: 3.5.5 |Anaconda custom (64-bit)| (default, May 13 2018, 21:12:35) \n",
+      "[GCC 7.2.0]\n",
+      "Pandas version: 0.23.0\n"
      ]
     }
    ],
@@ -411,13 +412,33 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "RMSE:\t\t1.054252\n",
-      "MAE:\t\t0.846033\n",
-      "rsquared:\t0.136435\n",
-      "exp var:\t0.136446\n"
+     "ename": "KeyError",
+     "evalue": "'Rating'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/indexes/base.py\u001b[0m in \u001b[0;36mget_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3062\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3063\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3064\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'Rating'",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-7-66b9df120fc3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      8\u001b[0m }\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m \u001b[0meval_rmse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrmse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbaseline_predictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcols\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0meval_mae\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmae\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbaseline_predictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcols\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0meval_rsquared\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrsquared\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbaseline_predictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcols\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/data/home/zhle/notebooks/Recommenders/reco_utils/evaluation/python_evaluation.py\u001b[0m in \u001b[0;36mcheck_column_dtypes_wrapper\u001b[0;34m(rating_true, rating_pred, col_user, col_item, col_rating, col_prediction, *args, **kwargs)\u001b[0m\n\u001b[1;32m     81\u001b[0m             \u001b[0mcol_prediction\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcol_prediction\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     82\u001b[0m             \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 83\u001b[0;31m             \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     84\u001b[0m         )\n\u001b[1;32m     85\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mcheck_column_dtypes_wrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/data/home/zhle/notebooks/Recommenders/reco_utils/evaluation/python_evaluation.py\u001b[0m in \u001b[0;36mrmse\u001b[0;34m(rating_true, rating_pred, col_user, col_item, col_rating, col_prediction)\u001b[0m\n\u001b[1;32m    155\u001b[0m     return np.sqrt(\n\u001b[1;32m    156\u001b[0m         mean_squared_error(\n\u001b[0;32m--> 157\u001b[0;31m             \u001b[0mrating_true_pred\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcol_rating\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrating_true_pred\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcol_prediction\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    158\u001b[0m         )\n\u001b[1;32m    159\u001b[0m     )\n",
+      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2683\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_multilevel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2684\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2685\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2686\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2687\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_getitem_column\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2690\u001b[0m         \u001b[0;31m# get column\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2691\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolumns\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_unique\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2692\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_item_cache\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2693\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2694\u001b[0m         \u001b[0;31m# duplicate columns & possible reduce dimensionality\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/generic.py\u001b[0m in \u001b[0;36m_get_item_cache\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m   2484\u001b[0m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2485\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mres\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2486\u001b[0;31m             \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2487\u001b[0m             \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_box_item_values\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2488\u001b[0m             \u001b[0mcache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/internals.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, item, fastpath)\u001b[0m\n\u001b[1;32m   4113\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   4114\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misna\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 4115\u001b[0;31m                 \u001b[0mloc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   4116\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   4117\u001b[0m                 \u001b[0mindexer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0misna\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/indexes/base.py\u001b[0m in \u001b[0;36mget_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3063\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3064\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3065\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_maybe_cast_indexer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3066\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3067\u001b[0m         \u001b[0mindexer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_indexer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmethod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtolerance\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtolerance\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'Rating'"
      ]
     }
    ],
@@ -462,78 +483,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>MovieId</th>\n",
-       "      <th>Count</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>50</td>\n",
-       "      <td>426</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>100</td>\n",
-       "      <td>396</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>258</td>\n",
-       "      <td>390</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>181</td>\n",
-       "      <td>384</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>286</td>\n",
-       "      <td>363</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   MovieId  Count\n",
-       "0       50    426\n",
-       "1      100    396\n",
-       "2      258    390\n",
-       "3      181    384\n",
-       "4      286    363"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "item_counts = train['MovieId'].value_counts().to_frame().reset_index()\n",
     "item_counts.columns = ['MovieId', 'Count']\n",
@@ -542,18 +494,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of user-item pairs: 1547463\n",
-      "After remove seen items: 1472463\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "user_item_col = ['UserId', 'MovieId']\n",
     "\n",
@@ -574,84 +517,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>MovieId</th>\n",
-       "      <th>Count</th>\n",
-       "      <th>UserId</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>50</td>\n",
-       "      <td>426</td>\n",
-       "      <td>600</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>50</td>\n",
-       "      <td>426</td>\n",
-       "      <td>607</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>50</td>\n",
-       "      <td>426</td>\n",
-       "      <td>697</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>50</td>\n",
-       "      <td>426</td>\n",
-       "      <td>774</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>50</td>\n",
-       "      <td>426</td>\n",
-       "      <td>666</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   MovieId  Count  UserId\n",
-       "0       50    426     600\n",
-       "1       50    426     607\n",
-       "2       50    426     697\n",
-       "3       50    426     774\n",
-       "4       50    426     666"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Generate recommendations\n",
     "baseline_recommendations = pd.merge(item_counts, users_items_remove_seen, on=['MovieId'], how='inner')\n",
@@ -660,20 +528,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MAP:\t0.052850\n",
-      "NDCG@K:\t0.248061\n",
-      "Precision@K:\t0.223754\n",
-      "Recall@K:\t0.108826\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "k = 10\n",
     "\n",
@@ -699,50 +556,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {},
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "if is_jupyter():\n",
     "    # Record results with papermill for unit-tests\n",
@@ -791,7 +607,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.5.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/02_model/baseline_deep_dive.ipynb
+++ b/notebooks/02_model/baseline_deep_dive.ipynb
@@ -59,9 +59,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "System version: 3.5.5 |Anaconda custom (64-bit)| (default, May 13 2018, 21:12:35) \n",
-      "[GCC 7.2.0]\n",
-      "Pandas version: 0.23.0\n"
+      "System version: 3.6.0 | packaged by conda-forge | (default, Feb  9 2017, 14:36:55) \n",
+      "[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)]\n",
+      "Pandas version: 0.23.4\n"
      ]
     }
    ],
@@ -412,33 +412,13 @@
    "metadata": {},
    "outputs": [
     {
-     "ename": "KeyError",
-     "evalue": "'Rating'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/indexes/base.py\u001b[0m in \u001b[0;36mget_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3062\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3063\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3064\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'Rating'",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-66b9df120fc3>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      8\u001b[0m }\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m \u001b[0meval_rmse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrmse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbaseline_predictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcols\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m \u001b[0meval_mae\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmae\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbaseline_predictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcols\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0meval_rsquared\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrsquared\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbaseline_predictions\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcols\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/data/home/zhle/notebooks/Recommenders/reco_utils/evaluation/python_evaluation.py\u001b[0m in \u001b[0;36mcheck_column_dtypes_wrapper\u001b[0;34m(rating_true, rating_pred, col_user, col_item, col_rating, col_prediction, *args, **kwargs)\u001b[0m\n\u001b[1;32m     81\u001b[0m             \u001b[0mcol_prediction\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcol_prediction\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     82\u001b[0m             \u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 83\u001b[0;31m             \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     84\u001b[0m         )\n\u001b[1;32m     85\u001b[0m     \u001b[0;32mreturn\u001b[0m \u001b[0mcheck_column_dtypes_wrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/data/home/zhle/notebooks/Recommenders/reco_utils/evaluation/python_evaluation.py\u001b[0m in \u001b[0;36mrmse\u001b[0;34m(rating_true, rating_pred, col_user, col_item, col_rating, col_prediction)\u001b[0m\n\u001b[1;32m    155\u001b[0m     return np.sqrt(\n\u001b[1;32m    156\u001b[0m         mean_squared_error(\n\u001b[0;32m--> 157\u001b[0;31m             \u001b[0mrating_true_pred\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcol_rating\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrating_true_pred\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcol_prediction\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    158\u001b[0m         )\n\u001b[1;32m    159\u001b[0m     )\n",
-      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2683\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_multilevel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2684\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2685\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2686\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2687\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_getitem_column\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/frame.py\u001b[0m in \u001b[0;36m_getitem_column\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   2690\u001b[0m         \u001b[0;31m# get column\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2691\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcolumns\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mis_unique\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2692\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_get_item_cache\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2693\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2694\u001b[0m         \u001b[0;31m# duplicate columns & possible reduce dimensionality\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/generic.py\u001b[0m in \u001b[0;36m_get_item_cache\u001b[0;34m(self, item)\u001b[0m\n\u001b[1;32m   2484\u001b[0m         \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2485\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mres\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2486\u001b[0;31m             \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2487\u001b[0m             \u001b[0mres\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_box_item_values\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2488\u001b[0m             \u001b[0mcache\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mres\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/internals.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, item, fastpath)\u001b[0m\n\u001b[1;32m   4113\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   4114\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misna\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 4115\u001b[0;31m                 \u001b[0mloc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mitem\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   4116\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   4117\u001b[0m                 \u001b[0mindexer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0misna\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/anaconda/envs/py35/lib/python3.5/site-packages/pandas/core/indexes/base.py\u001b[0m in \u001b[0;36mget_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3063\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3064\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mKeyError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3065\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_loc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_maybe_cast_indexer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3066\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3067\u001b[0m         \u001b[0mindexer\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_indexer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmethod\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtolerance\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtolerance\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/index.pyx\u001b[0m in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;32mpandas/_libs/hashtable_class_helper.pxi\u001b[0m in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'Rating'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "RMSE:\t\t1.054252\n",
+      "MAE:\t\t0.846033\n",
+      "rsquared:\t0.136435\n",
+      "exp var:\t0.136446\n"
      ]
     }
    ],
@@ -483,9 +463,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>MovieId</th>\n",
+       "      <th>Count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>50</td>\n",
+       "      <td>426</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>100</td>\n",
+       "      <td>396</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>258</td>\n",
+       "      <td>390</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>181</td>\n",
+       "      <td>384</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>286</td>\n",
+       "      <td>363</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   MovieId  Count\n",
+       "0       50    426\n",
+       "1      100    396\n",
+       "2      258    390\n",
+       "3      181    384\n",
+       "4      286    363"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "item_counts = train['MovieId'].value_counts().to_frame().reset_index()\n",
     "item_counts.columns = ['MovieId', 'Count']\n",
@@ -494,9 +543,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of user-item pairs: 1547463\n",
+      "After remove seen items: 1472463\n"
+     ]
+    }
+   ],
    "source": [
     "user_item_col = ['UserId', 'MovieId']\n",
     "\n",
@@ -517,9 +575,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>MovieId</th>\n",
+       "      <th>Count</th>\n",
+       "      <th>UserId</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>50</td>\n",
+       "      <td>426</td>\n",
+       "      <td>600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>50</td>\n",
+       "      <td>426</td>\n",
+       "      <td>607</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>50</td>\n",
+       "      <td>426</td>\n",
+       "      <td>697</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>50</td>\n",
+       "      <td>426</td>\n",
+       "      <td>774</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>50</td>\n",
+       "      <td>426</td>\n",
+       "      <td>666</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   MovieId  Count  UserId\n",
+       "0       50    426     600\n",
+       "1       50    426     607\n",
+       "2       50    426     697\n",
+       "3       50    426     774\n",
+       "4       50    426     666"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Generate recommendations\n",
     "baseline_recommendations = pd.merge(item_counts, users_items_remove_seen, on=['MovieId'], how='inner')\n",
@@ -528,9 +661,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MAP:\t0.052850\n",
+      "NDCG@K:\t0.248061\n",
+      "Precision@K:\t0.223754\n",
+      "Recall@K:\t0.108826\n"
+     ]
+    }
+   ],
    "source": [
     "k = 10\n",
     "\n",
@@ -556,9 +700,82 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "map": 0.052849604708810824
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "ndcg": 0.24806137846989768
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "precision": 0.22375397667020147
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "recall": 0.10882579657822154
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "rmse": 1.0542517935158313
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "mae": 0.8460334455026904
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "exp_var": 0.1364455189608914
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/papermill.record+json": {
+       "rsquared": 0.13643475734890176
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "if is_jupyter():\n",
     "    # Record results with papermill for unit-tests\n",
@@ -593,9 +810,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6 (recommender)",
    "language": "python",
-   "name": "python3"
+   "name": "recommender"
   },
   "language_info": {
    "codemirror_mode": {
@@ -607,7 +824,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/02_model/surprise_svd_deep_dive.ipynb
+++ b/notebooks/02_model/surprise_svd_deep_dive.ipynb
@@ -261,7 +261,7 @@
     {
      "data": {
       "text/plain": [
-       "<surprise.trainset.Trainset at 0x7f0d34ff2358>"
+       "<surprise.trainset.Trainset at 0x7f155cb6fb70>"
       ]
      },
      "execution_count": 5,
@@ -330,7 +330,7 @@
       "Processing epoch 27\n",
       "Processing epoch 28\n",
       "Processing epoch 29\n",
-      "Took 10.899535417556763 seconds for training.\n"
+      "Took 11.266653060913086 seconds for training.\n"
      ]
     }
    ],
@@ -388,32 +388,32 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>600.0</td>\n",
-       "      <td>651.0</td>\n",
+       "      <td>600</td>\n",
+       "      <td>651</td>\n",
        "      <td>4.118534</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>607.0</td>\n",
-       "      <td>494.0</td>\n",
+       "      <td>607</td>\n",
+       "      <td>494</td>\n",
        "      <td>3.728216</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>875.0</td>\n",
-       "      <td>1103.0</td>\n",
+       "      <td>875</td>\n",
+       "      <td>1103</td>\n",
        "      <td>4.224524</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>648.0</td>\n",
-       "      <td>238.0</td>\n",
+       "      <td>648</td>\n",
+       "      <td>238</td>\n",
        "      <td>4.225331</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>113.0</td>\n",
-       "      <td>273.0</td>\n",
+       "      <td>113</td>\n",
+       "      <td>273</td>\n",
        "      <td>4.043100</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -422,11 +422,11 @@
       ],
       "text/plain": [
        "   userID  itemID  prediction\n",
-       "0   600.0   651.0    4.118534\n",
-       "1   607.0   494.0    3.728216\n",
-       "2   875.0  1103.0    4.224524\n",
-       "3   648.0   238.0    4.225331\n",
-       "4   113.0   273.0    4.043100"
+       "0     600     651    4.118534\n",
+       "1     607     494    3.728216\n",
+       "2     875    1103    4.224524\n",
+       "3     648     238    4.225331\n",
+       "4     113     273    4.043100"
       ]
      },
      "execution_count": 7,
@@ -444,6 +444,8 @@
     "predictions = predictions.rename(index=str, columns={'uid': 'userID', 'iid': 'itemID',\n",
     "                                                     'est': 'prediction'})\n",
     "predictions = predictions.drop(['details', 'r_ui'], axis='columns')\n",
+    "for col in ['userID', 'itemID']:\n",
+    "    predictions[col] = predictions[col].astype(int)\n",
     "predictions.head()"
    ]
   },
@@ -465,7 +467,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Took 22.800930976867676 seconds for prediction.\n"
+      "Took 28.221018314361572 seconds for prediction.\n"
      ]
     }
    ],
@@ -676,7 +678,7 @@
     {
      "data": {
       "application/papermill.record+json": {
-       "MAP": 0.01301811070273736
+       "map": 0.01301811070273736
       }
      },
      "metadata": {},
@@ -685,7 +687,7 @@
     {
      "data": {
       "application/papermill.record+json": {
-       "NDCG": 0.09996004125699856
+       "ndcg": 0.09996004125699856
       }
      },
      "metadata": {},
@@ -712,7 +714,7 @@
     {
      "data": {
       "application/papermill.record+json": {
-       "train_time": 10.899535417556763
+       "train_time": 11.266653060913086
       }
      },
      "metadata": {},
@@ -721,7 +723,7 @@
     {
      "data": {
       "application/papermill.record+json": {
-       "test_time": 22.800930976867676
+       "test_time": 28.221018314361572
       }
      },
      "metadata": {},
@@ -757,9 +759,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.6 (recommender)",
    "language": "python",
-   "name": "python3"
+   "name": "recommender"
   },
   "language_info": {
    "codemirror_mode": {
@@ -771,7 +773,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/notebooks/02_model/vowpal_wabbit_deep_dive.ipynb
+++ b/notebooks/02_model/vowpal_wabbit_deep_dive.ipynb
@@ -61,16 +61,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "System version: 3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34) \n",
-      "[GCC 7.3.0]\n",
-      "Pandas version: 0.24.1\n"
+      "System version: 3.6.0 | packaged by conda-forge | (default, Feb  9 2017, 14:36:55) \n",
+      "[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)]\n",
+      "Pandas version: 0.23.4\n"
      ]
     }
    ],
@@ -98,7 +98,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {
     "tags": [
      "parameters"
@@ -222,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "scrolled": true
    },
@@ -308,8 +308,8 @@
        "      <td>0.716</td>\n",
        "      <td>0.232598</td>\n",
        "      <td>0.232601</td>\n",
-       "      <td>7.468423</td>\n",
-       "      <td>4.190349</td>\n",
+       "      <td>7.322505</td>\n",
+       "      <td>3.410463</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -320,10 +320,10 @@
        "Linear Regression  0.993821  0.716  0.232598            0.232601   \n",
        "\n",
        "                   Train Time (ms)  Test Time (ms)  \n",
-       "Linear Regression         7.468423        4.190349  "
+       "Linear Regression         7.322505        3.410463  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -372,6 +372,114 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RMSE</th>\n",
+       "      <th>MAE</th>\n",
+       "      <th>R2</th>\n",
+       "      <th>Explained Variance</th>\n",
+       "      <th>Train Time (ms)</th>\n",
+       "      <th>Test Time (ms)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Linear Regression</th>\n",
+       "      <td>0.993821</td>\n",
+       "      <td>0.71600</td>\n",
+       "      <td>0.232598</td>\n",
+       "      <td>0.232601</td>\n",
+       "      <td>7.322505</td>\n",
+       "      <td>3.410463</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Linear Regression w/ Interaction</th>\n",
+       "      <td>0.995751</td>\n",
+       "      <td>0.72024</td>\n",
+       "      <td>0.229615</td>\n",
+       "      <td>0.229671</td>\n",
+       "      <td>7.741038</td>\n",
+       "      <td>4.576859</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      RMSE      MAE        R2  \\\n",
+       "Linear Regression                 0.993821  0.71600  0.232598   \n",
+       "Linear Regression w/ Interaction  0.995751  0.72024  0.229615   \n",
+       "\n",
+       "                                  Explained Variance  Train Time (ms)  \\\n",
+       "Linear Regression                           0.232601         7.322505   \n",
+       "Linear Regression w/ Interaction            0.229671         7.741038   \n",
+       "\n",
+       "                                  Test Time (ms)  \n",
+       "Linear Regression                       3.410463  \n",
+       "Linear Regression w/ Interaction        4.576859  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Quick description of command line parameters used\n",
+    "  -b <N>: sets the memory size to 2<sup>N</sup> entries\n",
+    "  -q <ab>: create quadratic feature interactions between features in namespaces starting with 'a' and 'b' \n",
+    "\"\"\"\n",
+    "train_params = 'vw -b 26 -q ui -f {model} -d {data} --quiet'.format(model=saved_model_path, data=train_path)\n",
+    "test_params = 'vw -i {model} -d {data} -t -p {pred} --quiet'.format(model=saved_model_path, data=test_path, pred=prediction_path)\n",
+    "\n",
+    "result = run_vw(train_params=train_params,\n",
+    "                test_params=test_params,\n",
+    "                test_data=test,\n",
+    "                prediction_path=prediction_path)\n",
+    "saved_result = result\n",
+    "\n",
+    "comparison = comparison.append(pd.DataFrame(result, index=['Linear Regression w/ Interaction']))\n",
+    "comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2.3 Multinomial Logistic Regression\n",
+    "\n",
+    "An alternative to linear regression is to leverage multinomial logistic regression, or multiclass classification, which treats each rating value as a distinct class. \n",
+    "\n",
+    "This avoids any non integer results, but also reduces the training data for each class which could lead to poorer performance if the counts of different rating levels are skewed.\n",
+    "\n",
+    "Basic multiclass logistic regression can be accomplished using the One Against All approach specified by the '--oaa N' option, where N is the number of classes and proving the logistic option for the loss function to be used."
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
    "outputs": [
@@ -411,8 +519,8 @@
        "      <td>0.71600</td>\n",
        "      <td>0.232598</td>\n",
        "      <td>0.232601</td>\n",
-       "      <td>7.468423</td>\n",
-       "      <td>4.190349</td>\n",
+       "      <td>7.322505</td>\n",
+       "      <td>3.410463</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Linear Regression w/ Interaction</th>\n",
@@ -420,116 +528,8 @@
        "      <td>0.72024</td>\n",
        "      <td>0.229615</td>\n",
        "      <td>0.229671</td>\n",
-       "      <td>7.139377</td>\n",
-       "      <td>4.759148</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                      RMSE      MAE        R2  \\\n",
-       "Linear Regression                 0.993821  0.71600  0.232598   \n",
-       "Linear Regression w/ Interaction  0.995751  0.72024  0.229615   \n",
-       "\n",
-       "                                  Explained Variance  Train Time (ms)  \\\n",
-       "Linear Regression                           0.232601         7.468423   \n",
-       "Linear Regression w/ Interaction            0.229671         7.139377   \n",
-       "\n",
-       "                                  Test Time (ms)  \n",
-       "Linear Regression                       4.190349  \n",
-       "Linear Regression w/ Interaction        4.759148  "
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "\"\"\"\n",
-    "Quick description of command line parameters used\n",
-    "  -b <N>: sets the memory size to 2<sup>N</sup> entries\n",
-    "  -q <ab>: create quadratic feature interactions between features in namespaces starting with 'a' and 'b' \n",
-    "\"\"\"\n",
-    "train_params = 'vw -b 26 -q ui -f {model} -d {data} --quiet'.format(model=saved_model_path, data=train_path)\n",
-    "test_params = 'vw -i {model} -d {data} -t -p {pred} --quiet'.format(model=saved_model_path, data=test_path, pred=prediction_path)\n",
-    "\n",
-    "result = run_vw(train_params=train_params,\n",
-    "                test_params=test_params,\n",
-    "                test_data=test,\n",
-    "                prediction_path=prediction_path)\n",
-    "saved_result = result\n",
-    "\n",
-    "comparison = comparison.append(pd.DataFrame(result, index=['Linear Regression w/ Interaction']))\n",
-    "comparison"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2.3 Multinomial Logistic Regression\n",
-    "\n",
-    "An alternative to linear regression is to leverage multinomial logistic regression, or multiclass classification, which treats each rating value as a distinct class. \n",
-    "\n",
-    "This avoids any non integer results, but also reduces the training data for each class which could lead to poorer performance if the counts of different rating levels are skewed.\n",
-    "\n",
-    "Basic multiclass logistic regression can be accomplished using the One Against All approach specified by the '--oaa N' option, where N is the number of classes and proving the logistic option for the loss function to be used."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>RMSE</th>\n",
-       "      <th>MAE</th>\n",
-       "      <th>R2</th>\n",
-       "      <th>Explained Variance</th>\n",
-       "      <th>Train Time (ms)</th>\n",
-       "      <th>Test Time (ms)</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>Linear Regression</th>\n",
-       "      <td>0.993821</td>\n",
-       "      <td>0.71600</td>\n",
-       "      <td>0.232598</td>\n",
-       "      <td>0.232601</td>\n",
-       "      <td>7.468423</td>\n",
-       "      <td>4.190349</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Linear Regression w/ Interaction</th>\n",
-       "      <td>0.995751</td>\n",
-       "      <td>0.72024</td>\n",
-       "      <td>0.229615</td>\n",
-       "      <td>0.229671</td>\n",
-       "      <td>7.139377</td>\n",
-       "      <td>4.759148</td>\n",
+       "      <td>7.741038</td>\n",
+       "      <td>4.576859</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Multinomial Regression</th>\n",
@@ -537,8 +537,8 @@
        "      <td>0.75628</td>\n",
        "      <td>0.040997</td>\n",
        "      <td>0.071052</td>\n",
-       "      <td>7.229033</td>\n",
-       "      <td>5.703576</td>\n",
+       "      <td>7.927169</td>\n",
+       "      <td>4.657901</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -551,17 +551,17 @@
        "Multinomial Regression            1.110982  0.75628  0.040997   \n",
        "\n",
        "                                  Explained Variance  Train Time (ms)  \\\n",
-       "Linear Regression                           0.232601         7.468423   \n",
-       "Linear Regression w/ Interaction            0.229671         7.139377   \n",
-       "Multinomial Regression                      0.071052         7.229033   \n",
+       "Linear Regression                           0.232601         7.322505   \n",
+       "Linear Regression w/ Interaction            0.229671         7.741038   \n",
+       "Multinomial Regression                      0.071052         7.927169   \n",
        "\n",
        "                                  Test Time (ms)  \n",
-       "Linear Regression                       4.190349  \n",
-       "Linear Regression w/ Interaction        4.759148  \n",
-       "Multinomial Regression                  5.703576  "
+       "Linear Regression                       3.410463  \n",
+       "Linear Regression w/ Interaction        4.576859  \n",
+       "Multinomial Regression                  4.657901  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -600,7 +600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "scrolled": true
    },
@@ -641,8 +641,8 @@
        "      <td>0.716000</td>\n",
        "      <td>0.232598</td>\n",
        "      <td>0.232601</td>\n",
-       "      <td>7.468423</td>\n",
-       "      <td>4.190349</td>\n",
+       "      <td>7.322505</td>\n",
+       "      <td>3.410463</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Linear Regression w/ Interaction</th>\n",
@@ -650,8 +650,8 @@
        "      <td>0.720240</td>\n",
        "      <td>0.229615</td>\n",
        "      <td>0.229671</td>\n",
-       "      <td>7.139377</td>\n",
-       "      <td>4.759148</td>\n",
+       "      <td>7.741038</td>\n",
+       "      <td>4.576859</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Multinomial Regression</th>\n",
@@ -659,8 +659,8 @@
        "      <td>0.756280</td>\n",
        "      <td>0.040997</td>\n",
        "      <td>0.071052</td>\n",
-       "      <td>7.229033</td>\n",
-       "      <td>5.703576</td>\n",
+       "      <td>7.927169</td>\n",
+       "      <td>4.657901</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Logistic Regression</th>\n",
@@ -668,8 +668,8 @@
        "      <td>0.411213</td>\n",
        "      <td>0.084716</td>\n",
        "      <td>0.141296</td>\n",
-       "      <td>6.965979</td>\n",
-       "      <td>3.276018</td>\n",
+       "      <td>9.071164</td>\n",
+       "      <td>2.526298</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -683,19 +683,19 @@
        "Logistic Regression               0.729964  0.411213  0.084716   \n",
        "\n",
        "                                  Explained Variance  Train Time (ms)  \\\n",
-       "Linear Regression                           0.232601         7.468423   \n",
-       "Linear Regression w/ Interaction            0.229671         7.139377   \n",
-       "Multinomial Regression                      0.071052         7.229033   \n",
-       "Logistic Regression                         0.141296         6.965979   \n",
+       "Linear Regression                           0.232601         7.322505   \n",
+       "Linear Regression w/ Interaction            0.229671         7.741038   \n",
+       "Multinomial Regression                      0.071052         7.927169   \n",
+       "Logistic Regression                         0.141296         9.071164   \n",
        "\n",
        "                                  Test Time (ms)  \n",
-       "Linear Regression                       4.190349  \n",
-       "Linear Regression w/ Interaction        4.759148  \n",
-       "Multinomial Regression                  5.703576  \n",
-       "Logistic Regression                     3.276018  "
+       "Linear Regression                       3.410463  \n",
+       "Linear Regression w/ Interaction        4.576859  \n",
+       "Multinomial Regression                  4.657901  \n",
+       "Logistic Regression                     2.526298  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -729,6 +729,148 @@
     "The first approach performs matrix factorization based on Singular Value Decomposition (SVD) to learn a low rank approximation for the user-item rating matix. It is is called using the '--rank' command line argument.\n",
     "\n",
     "See the [Matrix Factorization Example](https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Matrix-factorization-example) for more detail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RMSE</th>\n",
+       "      <th>MAE</th>\n",
+       "      <th>R2</th>\n",
+       "      <th>Explained Variance</th>\n",
+       "      <th>Train Time (ms)</th>\n",
+       "      <th>Test Time (ms)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Linear Regression</th>\n",
+       "      <td>0.993821</td>\n",
+       "      <td>0.716000</td>\n",
+       "      <td>0.232598</td>\n",
+       "      <td>0.232601</td>\n",
+       "      <td>7.322505</td>\n",
+       "      <td>3.410463</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Linear Regression w/ Interaction</th>\n",
+       "      <td>0.995751</td>\n",
+       "      <td>0.720240</td>\n",
+       "      <td>0.229615</td>\n",
+       "      <td>0.229671</td>\n",
+       "      <td>7.741038</td>\n",
+       "      <td>4.576859</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Multinomial Regression</th>\n",
+       "      <td>1.110982</td>\n",
+       "      <td>0.756280</td>\n",
+       "      <td>0.040997</td>\n",
+       "      <td>0.071052</td>\n",
+       "      <td>7.927169</td>\n",
+       "      <td>4.657901</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Logistic Regression</th>\n",
+       "      <td>0.729964</td>\n",
+       "      <td>0.411213</td>\n",
+       "      <td>0.084716</td>\n",
+       "      <td>0.141296</td>\n",
+       "      <td>9.071164</td>\n",
+       "      <td>2.526298</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Matrix Factorization (Rank)</th>\n",
+       "      <td>0.999960</td>\n",
+       "      <td>0.723760</td>\n",
+       "      <td>0.223088</td>\n",
+       "      <td>0.223176</td>\n",
+       "      <td>7.060212</td>\n",
+       "      <td>4.429490</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                      RMSE       MAE        R2  \\\n",
+       "Linear Regression                 0.993821  0.716000  0.232598   \n",
+       "Linear Regression w/ Interaction  0.995751  0.720240  0.229615   \n",
+       "Multinomial Regression            1.110982  0.756280  0.040997   \n",
+       "Logistic Regression               0.729964  0.411213  0.084716   \n",
+       "Matrix Factorization (Rank)       0.999960  0.723760  0.223088   \n",
+       "\n",
+       "                                  Explained Variance  Train Time (ms)  \\\n",
+       "Linear Regression                           0.232601         7.322505   \n",
+       "Linear Regression w/ Interaction            0.229671         7.741038   \n",
+       "Multinomial Regression                      0.071052         7.927169   \n",
+       "Logistic Regression                         0.141296         9.071164   \n",
+       "Matrix Factorization (Rank)                 0.223176         7.060212   \n",
+       "\n",
+       "                                  Test Time (ms)  \n",
+       "Linear Regression                       3.410463  \n",
+       "Linear Regression w/ Interaction        4.576859  \n",
+       "Multinomial Regression                  4.657901  \n",
+       "Logistic Regression                     2.526298  \n",
+       "Matrix Factorization (Rank)             4.429490  "
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Quick description of command line parameters used\n",
+    "  --rank <N>: sets the number of latent factors in the reduced matrix\n",
+    "\"\"\"\n",
+    "train_params = 'vw --rank 5 -q ui -f {model} -d {data} --quiet'.format(model=model_path, data=train_path)\n",
+    "test_params = 'vw -i {model} -d {data} -t -p {pred} --quiet'.format(model=model_path, data=test_path, pred=prediction_path)\n",
+    "\n",
+    "result = run_vw(train_params=train_params,\n",
+    "                test_params=test_params,\n",
+    "                test_data=test,\n",
+    "                prediction_path=prediction_path)\n",
+    "\n",
+    "comparison = comparison.append(pd.DataFrame(result, index=['Matrix Factorization (Rank)']))\n",
+    "comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3.2. Factorization Machine Based Matrix Factorization\n",
+    "\n",
+    "An alternative approach based on [Rendel's factorization machines](https://cseweb.ucsd.edu/classes/fa17/cse291-b/reading/Rendle2010FM.pdf) is called using '--lrq' (low rank quadratic). More LRQ details in this [demo](https://github.com/VowpalWabbit/vowpal_wabbit/tree/master/demo/movielens).\n",
+    "\n",
+    "This learns two lower rank matrices which are multiplied to generate an approximation of the user-item rating matrix. Compressing the matrix in this way leads to learning generalizable factors which avoids some of the limitations of using regression models with extremely sparse interaction features. This can lead to better convergence and smaller on-disk models.\n",
+    "\n",
+    "An additional term to improve performance is --lrqdropout which will dropout columns during training. This however tends to increase the optimal rank size. Other parameters such as L2 regularization can help avoid overfitting."
    ]
   },
   {
@@ -772,8 +914,8 @@
        "      <td>0.716000</td>\n",
        "      <td>0.232598</td>\n",
        "      <td>0.232601</td>\n",
-       "      <td>7.468423</td>\n",
-       "      <td>4.190349</td>\n",
+       "      <td>7.322505</td>\n",
+       "      <td>3.410463</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Linear Regression w/ Interaction</th>\n",
@@ -781,8 +923,8 @@
        "      <td>0.720240</td>\n",
        "      <td>0.229615</td>\n",
        "      <td>0.229671</td>\n",
-       "      <td>7.139377</td>\n",
-       "      <td>4.759148</td>\n",
+       "      <td>7.741038</td>\n",
+       "      <td>4.576859</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Multinomial Regression</th>\n",
@@ -790,8 +932,8 @@
        "      <td>0.756280</td>\n",
        "      <td>0.040997</td>\n",
        "      <td>0.071052</td>\n",
-       "      <td>7.229033</td>\n",
-       "      <td>5.703576</td>\n",
+       "      <td>7.927169</td>\n",
+       "      <td>4.657901</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Logistic Regression</th>\n",
@@ -799,8 +941,8 @@
        "      <td>0.411213</td>\n",
        "      <td>0.084716</td>\n",
        "      <td>0.141296</td>\n",
-       "      <td>6.965979</td>\n",
-       "      <td>3.276018</td>\n",
+       "      <td>9.071164</td>\n",
+       "      <td>2.526298</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Matrix Factorization (Rank)</th>\n",
@@ -808,150 +950,8 @@
        "      <td>0.723760</td>\n",
        "      <td>0.223088</td>\n",
        "      <td>0.223176</td>\n",
-       "      <td>7.299196</td>\n",
-       "      <td>4.956586</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                      RMSE       MAE        R2  \\\n",
-       "Linear Regression                 0.993821  0.716000  0.232598   \n",
-       "Linear Regression w/ Interaction  0.995751  0.720240  0.229615   \n",
-       "Multinomial Regression            1.110982  0.756280  0.040997   \n",
-       "Logistic Regression               0.729964  0.411213  0.084716   \n",
-       "Matrix Factorization (Rank)       0.999960  0.723760  0.223088   \n",
-       "\n",
-       "                                  Explained Variance  Train Time (ms)  \\\n",
-       "Linear Regression                           0.232601         7.468423   \n",
-       "Linear Regression w/ Interaction            0.229671         7.139377   \n",
-       "Multinomial Regression                      0.071052         7.229033   \n",
-       "Logistic Regression                         0.141296         6.965979   \n",
-       "Matrix Factorization (Rank)                 0.223176         7.299196   \n",
-       "\n",
-       "                                  Test Time (ms)  \n",
-       "Linear Regression                       4.190349  \n",
-       "Linear Regression w/ Interaction        4.759148  \n",
-       "Multinomial Regression                  5.703576  \n",
-       "Logistic Regression                     3.276018  \n",
-       "Matrix Factorization (Rank)             4.956586  "
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "\"\"\"\n",
-    "Quick description of command line parameters used\n",
-    "  --rank <N>: sets the number of latent factors in the reduced matrix\n",
-    "\"\"\"\n",
-    "train_params = 'vw --rank 5 -q ui -f {model} -d {data} --quiet'.format(model=model_path, data=train_path)\n",
-    "test_params = 'vw -i {model} -d {data} -t -p {pred} --quiet'.format(model=model_path, data=test_path, pred=prediction_path)\n",
-    "\n",
-    "result = run_vw(train_params=train_params,\n",
-    "                test_params=test_params,\n",
-    "                test_data=test,\n",
-    "                prediction_path=prediction_path)\n",
-    "\n",
-    "comparison = comparison.append(pd.DataFrame(result, index=['Matrix Factorization (Rank)']))\n",
-    "comparison"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3.2. Factorization Machine Based Matrix Factorization\n",
-    "\n",
-    "An alternative approach based on [Rendel's factorization machines](https://cseweb.ucsd.edu/classes/fa17/cse291-b/reading/Rendle2010FM.pdf) is called using '--lrq' (low rank quadratic). More LRQ details in this [demo](https://github.com/VowpalWabbit/vowpal_wabbit/tree/master/demo/movielens).\n",
-    "\n",
-    "This learns two lower rank matrices which are multiplied to generate an approximation of the user-item rating matrix. Compressing the matrix in this way leads to learning generalizable factors which avoids some of the limitations of using regression models with extremely sparse interaction features. This can lead to better convergence and smaller on-disk models.\n",
-    "\n",
-    "An additional term to improve performance is --lrqdropout which will dropout columns during training. This however tends to increase the optimal rank size. Other parameters such as L2 regularization can help avoid overfitting."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>RMSE</th>\n",
-       "      <th>MAE</th>\n",
-       "      <th>R2</th>\n",
-       "      <th>Explained Variance</th>\n",
-       "      <th>Train Time (ms)</th>\n",
-       "      <th>Test Time (ms)</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>Linear Regression</th>\n",
-       "      <td>0.993821</td>\n",
-       "      <td>0.716000</td>\n",
-       "      <td>0.232598</td>\n",
-       "      <td>0.232601</td>\n",
-       "      <td>7.468423</td>\n",
-       "      <td>4.190349</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Linear Regression w/ Interaction</th>\n",
-       "      <td>0.995751</td>\n",
-       "      <td>0.720240</td>\n",
-       "      <td>0.229615</td>\n",
-       "      <td>0.229671</td>\n",
-       "      <td>7.139377</td>\n",
-       "      <td>4.759148</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Multinomial Regression</th>\n",
-       "      <td>1.110982</td>\n",
-       "      <td>0.756280</td>\n",
-       "      <td>0.040997</td>\n",
-       "      <td>0.071052</td>\n",
-       "      <td>7.229033</td>\n",
-       "      <td>5.703576</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Logistic Regression</th>\n",
-       "      <td>0.729964</td>\n",
-       "      <td>0.411213</td>\n",
-       "      <td>0.084716</td>\n",
-       "      <td>0.141296</td>\n",
-       "      <td>6.965979</td>\n",
-       "      <td>3.276018</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Matrix Factorization (Rank)</th>\n",
-       "      <td>0.999960</td>\n",
-       "      <td>0.723760</td>\n",
-       "      <td>0.223088</td>\n",
-       "      <td>0.223176</td>\n",
-       "      <td>7.299196</td>\n",
-       "      <td>4.956586</td>\n",
+       "      <td>7.060212</td>\n",
+       "      <td>4.429490</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Matrix Factorization (LRQ)</th>\n",
@@ -959,8 +959,8 @@
        "      <td>0.735520</td>\n",
        "      <td>0.190580</td>\n",
        "      <td>0.190616</td>\n",
-       "      <td>7.135406</td>\n",
-       "      <td>3.755361</td>\n",
+       "      <td>7.452745</td>\n",
+       "      <td>2.819837</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -976,23 +976,23 @@
        "Matrix Factorization (LRQ)        1.020666  0.735520  0.190580   \n",
        "\n",
        "                                  Explained Variance  Train Time (ms)  \\\n",
-       "Linear Regression                           0.232601         7.468423   \n",
-       "Linear Regression w/ Interaction            0.229671         7.139377   \n",
-       "Multinomial Regression                      0.071052         7.229033   \n",
-       "Logistic Regression                         0.141296         6.965979   \n",
-       "Matrix Factorization (Rank)                 0.223176         7.299196   \n",
-       "Matrix Factorization (LRQ)                  0.190616         7.135406   \n",
+       "Linear Regression                           0.232601         7.322505   \n",
+       "Linear Regression w/ Interaction            0.229671         7.741038   \n",
+       "Multinomial Regression                      0.071052         7.927169   \n",
+       "Logistic Regression                         0.141296         9.071164   \n",
+       "Matrix Factorization (Rank)                 0.223176         7.060212   \n",
+       "Matrix Factorization (LRQ)                  0.190616         7.452745   \n",
        "\n",
        "                                  Test Time (ms)  \n",
-       "Linear Regression                       4.190349  \n",
-       "Linear Regression w/ Interaction        4.759148  \n",
-       "Multinomial Regression                  5.703576  \n",
-       "Logistic Regression                     3.276018  \n",
-       "Matrix Factorization (Rank)             4.956586  \n",
-       "Matrix Factorization (LRQ)              3.755361  "
+       "Linear Regression                       3.410463  \n",
+       "Linear Regression w/ Interaction        4.576859  \n",
+       "Multinomial Regression                  4.657901  \n",
+       "Logistic Regression                     2.526298  \n",
+       "Matrix Factorization (Rank)             4.429490  \n",
+       "Matrix Factorization (LRQ)              2.819837  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1040,7 +1040,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1064,7 +1064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1098,36 +1098,36 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>95.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>95</td>\n",
        "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>231.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>231</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
        "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>207.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>207</td>\n",
        "      <td>5.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>3</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>59.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>59</td>\n",
        "      <td>5.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1136,14 +1136,14 @@
       ],
       "text/plain": [
        "   prediction  userID  itemID  rating\n",
-       "0           3     1.0    95.0     4.0\n",
-       "1           3     1.0   231.0     1.0\n",
-       "2           3     1.0     3.0     4.0\n",
-       "3           3     1.0   207.0     5.0\n",
-       "4           3     1.0    59.0     5.0"
+       "0           3       1      95     4.0\n",
+       "1           3       1     231     1.0\n",
+       "2           3       1       3     4.0\n",
+       "3           3       1     207     5.0\n",
+       "4           3       1      59     5.0"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1161,12 +1161,17 @@
     "pred_data['prediction'] = pred_data['prediction'].apply(lambda x: int(max(1, min(5, round(x)))))\n",
     "\n",
     "top_k = get_top_k_items(pred_data, col_rating='prediction', k=TOP_K)[['prediction', 'userID', 'itemID', 'rating']]\n",
+    "\n",
+    "# convert dtypes of userID and itemID columns.\n",
+    "for col in ['userID', 'itemID']:\n",
+    "    top_k[col] = top_k[col].astype(int)\n",
+    "    \n",
     "top_k.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1194,8 +1199,8 @@
       "MAE: 0.72024\n",
       "R2: 0.22961479092361414\n",
       "Explained Variance: 0.22967066343101572\n",
-      "Train Time (ms): 7.139377000001446\n",
-      "Test Time (ms): 4.759147999997992\n",
+      "Train Time (ms): 7.741038000002476\n",
+      "Test Time (ms): 4.576859000000155\n",
       "MAP: 0.2568488766282023\n",
       "NDCG: 0.6533904587110557\n",
       "Precision: 0.5147381242387332\n",
@@ -1219,7 +1224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1261,7 +1266,7 @@
     {
      "data": {
       "application/papermill.record+json": {
-       "train_time": 7.139377000001446
+       "train_time": 7.741038000002476
       }
      },
      "metadata": {},
@@ -1270,7 +1275,7 @@
     {
      "data": {
       "application/papermill.record+json": {
-       "test_time": 0.00930852299998719
+       "test_time": 0.01111622999999895
       }
      },
      "metadata": {},
@@ -1330,7 +1335,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1353,9 +1358,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python (reco)",
+   "display_name": "Python 3.6 (recommender)",
    "language": "python",
-   "name": "reco"
+   "name": "recommender"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1367,7 +1372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -38,47 +38,47 @@ def merge_rating_true_pred(
         pd.DataFrame: Merged pd.DataFrame
     """
 
-    if col_user not in rating_true.columns:
-        raise ValueError("Schema of y_true not valid. Missing User Col")
-    if col_item not in rating_true.columns:
-        raise ValueError("Schema of y_true not valid. Missing Item Col")
-    if col_rating not in rating_true.columns:
-        raise ValueError("Schema of y_true not valid. Missing Rating Col")
-
-    if col_user not in rating_pred.columns:
-        # pragma : No Cover
-        raise ValueError("Schema of y_pred not valid. Missing User Col")
-    if col_item not in rating_pred.columns:
-        # pragma : No Cover
-        raise ValueError("Schema of y_pred not valid. Missing Item Col")
-    if col_prediction not in rating_pred.columns:
-        raise ValueError(
-            "Schema of y_true not valid. Missing Prediction Col: "
-            + str(rating_pred.columns)
-        )
-
-    # Check matching of input column types. The evaluator requires two dataframes have the same
-    # data types of the input columns.
-    if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
-        raise TypeError(
-            "Data types of column {} are different in true and prediction".format(
-                col_user
-            )
-        )
-
-    if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
-        raise TypeError(
-            "Data types of column {} are different in true and prediction".format(
-                col_item
-            )
-        )
-
-    if rating_true[col_rating].dtypes != rating_pred[col_prediction].dtypes:
-        raise TypeError(
-            "Data types of column {} and {} are different in true and prediction".format(
-                col_rating, col_prediction
-            )
-        )
+    # if col_user not in rating_true.columns:
+    #     raise ValueError("Schema of y_true not valid. Missing User Col")
+    # if col_item not in rating_true.columns:
+    #     raise ValueError("Schema of y_true not valid. Missing Item Col")
+    # if col_rating not in rating_true.columns:
+    #     raise ValueError("Schema of y_true not valid. Missing Rating Col")
+    #
+    # if col_user not in rating_pred.columns:
+    #     # pragma : No Cover
+    #     raise ValueError("Schema of y_pred not valid. Missing User Col")
+    # if col_item not in rating_pred.columns:
+    #     # pragma : No Cover
+    #     raise ValueError("Schema of y_pred not valid. Missing Item Col")
+    # if col_prediction not in rating_pred.columns:
+    #     raise ValueError(
+    #         "Schema of y_true not valid. Missing Prediction Col: "
+    #         + str(rating_pred.columns)
+    #     )
+    #
+    # # Check matching of input column types. The evaluator requires two dataframes have the same
+    # # data types of the input columns.
+    # if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
+    #     raise TypeError(
+    #         "Data types of column {} are different in true and prediction".format(
+    #             col_user
+    #         )
+    #     )
+    #
+    # if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
+    #     raise TypeError(
+    #         "Data types of column {} are different in true and prediction".format(
+    #             col_item
+    #         )
+    #     )
+    #
+    # if rating_true[col_rating].dtypes != rating_pred[col_prediction].dtypes:
+    #     raise TypeError(
+    #         "Data types of column {} and {} are different in true and prediction".format(
+    #             col_rating, col_prediction
+    #         )
+    #     )
 
     # Select the columns needed for evaluations
     rating_true = rating_true[[col_user, col_item, col_rating]]
@@ -105,6 +105,7 @@ def merge_rating_true_pred(
     return rating_true_pred
 
 
+@check_column_dtypes
 def rmse(
     rating_true,
     rating_pred,
@@ -136,6 +137,7 @@ def rmse(
     )
 
 
+@check_column_dtypes
 def mae(
     rating_true,
     rating_pred,
@@ -165,6 +167,7 @@ def mae(
     )
 
 
+@check_column_dtypes
 def rsquared(
     rating_true,
     rating_pred,
@@ -194,6 +197,7 @@ def rsquared(
     )
 
 
+@check_column_dtypes
 def exp_var(
     rating_true,
     rating_pred,
@@ -631,12 +635,12 @@ def get_top_k_items(
     )
 
 
-def check_data_columns(func):
-    '''
+def check_column_dtypes(func):
+    """
     Checks columns of dataframe inputs.
-    '''
+    """
     @wraps(func)
-    def check_data_columns_wrapper(
+    def check_column_dtypes_wrapper(
         rating_true,
         rating_pred,
         col_user,
@@ -679,4 +683,7 @@ def check_data_columns(func):
                     col_item
                 )
             )
+
+    return check_column_dtypes_wrapper
+
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -224,7 +224,7 @@ def _merge_ranking_true_pred(
         pd.DataFrame: new data frame of true data DataFrame of recommendation hits
             number of common users
     """
-
+    # Check existence of input columns.
     if col_user not in rating_true.columns:
         raise ValueError("Schema of y_true not valid. Missing User Col")
     if col_item not in rating_true.columns:
@@ -242,6 +242,19 @@ def _merge_ranking_true_pred(
         raise ValueError(
             "Schema of y_pred not valid. Missing Prediction Col: "
             + str(rating_pred.columns)
+        )
+
+    # Check matching of input column types. The evaluator requires two dataframes have the same
+    # data types of the input columns.
+    if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
+        raise TypeError("Data types of column {} are different in true and prediction".format(col_user))
+
+    if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
+        raise TypeError("Data types of column {} are different in true and prediction".format(col_item))
+
+    if rating_true[col_rating].dtypes != rating_pred[col_prediction].dtypes:
+        raise TypeError(
+            "Data types of column {} and {} are different in true and prediction".format(col_rating, col_prediction)
         )
 
     relevant_func = {"top_k": get_top_k_items}

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -354,9 +354,6 @@ def precision_at_k(
     Returns:
         float: precision at k (min=0, max=1)
     """
-    print(rating_true)
-    print(rating_pred)
-
     _, df_hit, n_users = merge_ranking_true_pred(
         rating_true,
         rating_pred,
@@ -379,11 +376,7 @@ def precision_at_k(
         .rename(columns={col_item: "hit"}, inplace=False)
     )
 
-    print(k)
-
     df_count_hit["precision"] = df_count_hit.apply(lambda x: (x.hit / k), axis=1)
-
-    print(df_count_hit)
 
     return np.float64(df_count_hit.agg({"precision": "sum"})) / n_users
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -37,24 +37,13 @@ def check_column_dtypes(f):
         **kwargs
     ):
         # check existence of input columns.
-        if col_user not in rating_true.columns:
-            raise ValueError("schema of y_true not valid. missing user col")
-        if col_item not in rating_true.columns:
-            raise ValueError("schema of y_true not valid. missing item col")
-        if col_rating not in rating_true.columns:
-            raise ValueError("schema of y_true not valid. missing rating col")
+        for col in [col_user, col_item, col_rating]:
+            if col not in rating_true.columns:
+                raise ValueError("schema of y_true not valid. missing {}".format(col))
 
-        if col_user not in rating_pred.columns:
-            # pragma : no cover
-            raise ValueError("schema of y_pred not valid. missing user col")
-        if col_item not in rating_pred.columns:
-            # pragma : no cover
-            raise ValueError("schema of y_pred not valid. missing item col")
-        if col_prediction not in rating_pred.columns:
-            raise ValueError(
-                "schema of y_pred not valid. missing prediction col: "
-                + str(rating_pred.columns)
-            )
+        for col in [col_user, col_item, col_rating]:
+            if col not in rating_pred.columns:
+                raise ValueError("schema of y_true not valid. missing {}".format(col))
 
         # check matching of input column types. the evaluator requires two dataframes have the same
         # data types of the input columns.

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -41,7 +41,7 @@ def check_column_dtypes(f):
             if col not in rating_true.columns:
                 raise ValueError("schema of y_true not valid. missing {}".format(col))
 
-        for col in [col_user, col_item, col_rating]:
+        for col in [col_user, col_item, col_prediction]:
             if col not in rating_pred.columns:
                 raise ValueError("schema of y_true not valid. missing {}".format(col))
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -32,7 +32,10 @@ def check_column_dtypes(f):
         col_user=DEFAULT_USER_COL,
         col_item=DEFAULT_ITEM_COL,
         col_rating=DEFAULT_RATING_COL,
-        col_prediction=PREDICTION_COL
+        col_prediction=PREDICTION_COL,
+        k=DEFAULT_K,
+        threshold=DEFAULT_THRESHOLD,
+        relevancy_method="top_k"
     ):
         # check existence of input columns.
         if col_user not in rating_true.columns:
@@ -250,6 +253,7 @@ def merge_ranking_true_pred(
     rating_pred,
     col_user,
     col_item,
+    col_rating,
     col_prediction,
     relevancy_method,
     k=DEFAULT_K,

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -33,9 +33,8 @@ def check_column_dtypes(f):
         col_item=DEFAULT_ITEM_COL,
         col_rating=DEFAULT_RATING_COL,
         col_prediction=PREDICTION_COL,
-        k=DEFAULT_K,
-        threshold=DEFAULT_THRESHOLD,
-        relevancy_method="top_k"
+        *args,
+        **kwargs
     ):
         # check existence of input columns.
         if col_user not in rating_true.columns:
@@ -74,15 +73,14 @@ def check_column_dtypes(f):
             )
 
         return f(
-            rating_true,
-            rating_pred,
+            rating_true=rating_true,
+            rating_pred=rating_pred,
             col_user=col_user,
             col_item=col_item,
             col_rating=col_rating,
             col_prediction=col_prediction,
-            k=k,
-            threshold=threshold,
-            relevancy_method=relevancy_method
+            *args,
+            **kwargs
         )
     return check_column_dtypes_wrapper
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -79,7 +79,10 @@ def check_column_dtypes(f):
             col_user=col_user,
             col_item=col_item,
             col_rating=col_rating,
-            col_prediction=col_prediction
+            col_prediction=col_prediction,
+            k=k,
+            threshold=threshold,
+            relevancy_method=relevancy_method
         )
     return check_column_dtypes_wrapper
 
@@ -353,6 +356,9 @@ def precision_at_k(
     Returns:
         float: precision at k (min=0, max=1)
     """
+    print(rating_true)
+    print(rating_pred)
+
     _, df_hit, n_users = merge_ranking_true_pred(
         rating_true,
         rating_pred,
@@ -375,7 +381,11 @@ def precision_at_k(
         .rename(columns={col_item: "hit"}, inplace=False)
     )
 
+    print(k)
+
     df_count_hit["precision"] = df_count_hit.apply(lambda x: (x.hit / k), axis=1)
+
+    print(df_count_hit)
 
     return np.float64(df_count_hit.agg({"precision": "sum"})) / n_users
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -154,7 +154,7 @@ def rmse(
 
     return np.sqrt(
         mean_squared_error(
-            rating_true_pred[col_rating], rating_true_pred[col_prediction]
+            rating_true_pred[DEFAULT_RATING_COL], rating_true_pred[PREDICTION_COL]
         )
     )
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -59,14 +59,24 @@ def merge_rating_true_pred(
     # Check matching of input column types. The evaluator requires two dataframes have the same
     # data types of the input columns.
     if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
-        raise TypeError("Data types of column {} are different in true and prediction".format(col_user))
+        raise TypeError(
+            "Data types of column {} are different in true and prediction".format(
+                col_user
+            )
+        )
 
     if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
-        raise TypeError("Data types of column {} are different in true and prediction".format(col_item))
+        raise TypeError(
+            "Data types of column {} are different in true and prediction".format(
+                col_item
+            )
+        )
 
     if rating_true[col_rating].dtypes != rating_pred[col_prediction].dtypes:
         raise TypeError(
-            "Data types of column {} and {} are different in true and prediction".format(col_rating, col_prediction)
+            "Data types of column {} and {} are different in true and prediction".format(
+                col_rating, col_prediction
+            )
         )
 
     # Select the columns needed for evaluations
@@ -260,10 +270,18 @@ def merge_ranking_true_pred(
     # Check matching of input column types. The evaluator requires two dataframes have the same
     # data types of the input columns.
     if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
-        raise TypeError("Data types of column {} are different in true and prediction".format(col_user))
+        raise TypeError(
+            "Data types of column {} are different in true and prediction".format(
+                col_user
+            )
+        )
 
     if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
-        raise TypeError("Data types of column {} are different in true and prediction".format(col_item))
+        raise TypeError(
+            "Data types of column {} are different in true and prediction".format(
+                col_item
+            )
+        )
 
     relevant_func = {"top_k": get_top_k_items}
 
@@ -585,7 +603,9 @@ def map_at_k(
     return np.float64(df_sum_all.agg({"map": "sum"})) / n_users
 
 
-def get_top_k_items(dataframe, col_user=DEFAULT_USER_COL, col_rating=DEFAULT_RATING_COL, k=DEFAULT_K):
+def get_top_k_items(
+    dataframe, col_user=DEFAULT_USER_COL, col_rating=DEFAULT_RATING_COL, k=DEFAULT_K
+):
     """Get the input customer-item-rating tuple in the format of Pandas
     DataFrame, output a Pandas DataFrame in the dense format of top k items
     for each user.
@@ -603,6 +623,8 @@ def get_top_k_items(dataframe, col_user=DEFAULT_USER_COL, col_rating=DEFAULT_RAT
     Return:
         pd.DataFrame: DataFrame of top k items for each user.
     """
-    return (dataframe.groupby(col_user, as_index=False)
-            .apply(lambda x: x.nlargest(k, col_rating))
-            .reset_index(drop=True))
+    return (
+        dataframe.groupby(col_user, as_index=False)
+        .apply(lambda x: x.nlargest(k, col_rating))
+        .reset_index(drop=True)
+    )

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+from functools import wraps
 from sklearn.metrics import (
     mean_squared_error,
     mean_absolute_error,
@@ -628,3 +629,54 @@ def get_top_k_items(
         .apply(lambda x: x.nlargest(k, col_rating))
         .reset_index(drop=True)
     )
+
+
+def check_data_columns(func):
+    '''
+    Checks columns of dataframe inputs.
+    '''
+    @wraps(func)
+    def check_data_columns_wrapper(
+        rating_true,
+        rating_pred,
+        col_user,
+        col_item,
+        col_rating,
+        col_prediction
+    ):
+        # check existence of input columns.
+        if col_user not in rating_true.columns:
+            raise ValueError("schema of y_true not valid. missing user col")
+        if col_item not in rating_true.columns:
+            raise ValueError("schema of y_true not valid. missing item col")
+        if col_rating not in rating_true.columns:
+            raise ValueError("schema of y_true not valid. missing rating col")
+
+        if col_user not in rating_pred.columns:
+            # pragma : no cover
+            raise ValueError("schema of y_pred not valid. missing user col")
+        if col_item not in rating_pred.columns:
+            # pragma : no cover
+            raise ValueError("schema of y_pred not valid. missing item col")
+        if col_prediction not in rating_pred.columns:
+            raise ValueError(
+                "schema of y_pred not valid. missing prediction col: "
+                + str(rating_pred.columns)
+            )
+
+        # check matching of input column types. the evaluator requires two dataframes have the same
+        # data types of the input columns.
+        if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
+            raise TypeError(
+                "data types of column {} are different in true and prediction".format(
+                    col_user
+                )
+            )
+
+        if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
+            raise TypeError(
+                "data types of column {} are different in true and prediction".format(
+                    col_item
+                )
+            )
+

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -56,6 +56,19 @@ def _merge_rating_true_pred(
             + str(rating_pred.columns)
         )
 
+    # Check matching of input column types. The evaluator requires two dataframes have the same
+    # data types of the input columns.
+    if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
+        raise TypeError("Data types of column {} are different in true and prediction".format(col_user))
+
+    if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
+        raise TypeError("Data types of column {} are different in true and prediction".format(col_item))
+
+    if rating_true[col_rating].dtypes != rating_pred[col_prediction].dtypes:
+        raise TypeError(
+            "Data types of column {} and {} are different in true and prediction".format(col_rating, col_prediction)
+        )
+
     # Select the columns needed for evaluations
     rating_true = rating_true[[col_user, col_item, col_rating]]
     rating_pred = rating_pred[[col_user, col_item, col_prediction]]
@@ -251,11 +264,6 @@ def _merge_ranking_true_pred(
 
     if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
         raise TypeError("Data types of column {} are different in true and prediction".format(col_item))
-
-    if rating_true[col_rating].dtypes != rating_pred[col_prediction].dtypes:
-        raise TypeError(
-            "Data types of column {} and {} are different in true and prediction".format(col_rating, col_prediction)
-        )
 
     relevant_func = {"top_k": get_top_k_items}
 

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -314,6 +314,7 @@ def merge_ranking_true_pred(
     return rating_true_new, df_hit, n_users
 
 
+@check_column_dtypes
 def precision_at_k(
     rating_true,
     rating_pred,
@@ -375,6 +376,7 @@ def precision_at_k(
     return np.float64(df_count_hit.agg({"precision": "sum"})) / n_users
 
 
+@check_column_dtypes
 def recall_at_k(
     rating_true,
     rating_pred,
@@ -439,6 +441,7 @@ def recall_at_k(
     return np.float64(df_count_all.agg({"recall": "sum"})) / n_users
 
 
+@check_column_dtypes
 def ndcg_at_k(
     rating_true,
     rating_pred,
@@ -517,6 +520,7 @@ def ndcg_at_k(
     return np.float64(df_ndcg.agg({"ndcg": "sum"})) / n_users
 
 
+@check_column_dtypes
 def map_at_k(
     rating_true,
     rating_pred,

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -24,6 +24,10 @@ from reco_utils.common.constants import (
 def check_column_dtypes(f):
     """
     Checks columns of dataframe inputs.
+
+    This includes the checks on 
+        1. whether the input columns exist in the input dataframes.
+        2. whether the data types of col_user as well as col_item are matched in the two input dataframes.
     """
     @wraps(f)
     def check_column_dtypes_wrapper(

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -20,7 +20,7 @@ from reco_utils.common.constants import (
 )
 
 
-def _merge_rating_true_pred(
+def merge_rating_true_pred(
     rating_true, rating_pred, col_user, col_item, col_rating, col_prediction
 ):
     """Join truth and prediction data frames on userID and itemID
@@ -115,7 +115,7 @@ def rmse(
     Returns:
         float: Root mean squared error.
     """
-    rating_true_pred = _merge_rating_true_pred(
+    rating_true_pred = merge_rating_true_pred(
         rating_true, rating_pred, col_user, col_item, col_rating, col_prediction
     )
     return np.sqrt(
@@ -146,7 +146,7 @@ def mae(
     Returns:
         float: Mean Absolute Error.
     """
-    rating_true_pred = _merge_rating_true_pred(
+    rating_true_pred = merge_rating_true_pred(
         rating_true, rating_pred, col_user, col_item, col_rating, col_prediction
     )
     return mean_absolute_error(
@@ -175,7 +175,7 @@ def rsquared(
     Returns:
         float: R squared (min=0, max=1).
     """
-    rating_true_pred = _merge_rating_true_pred(
+    rating_true_pred = merge_rating_true_pred(
         rating_true, rating_pred, col_user, col_item, col_rating, col_prediction
     )
     return r2_score(
@@ -204,7 +204,7 @@ def exp_var(
     Returns:
         float: Explained variance (min=0, max=1).
     """
-    rating_true_pred = _merge_rating_true_pred(
+    rating_true_pred = merge_rating_true_pred(
         rating_true, rating_pred, col_user, col_item, col_rating, col_prediction
     )
     return explained_variance_score(
@@ -212,7 +212,7 @@ def exp_var(
     )
 
 
-def _merge_ranking_true_pred(
+def merge_ranking_true_pred(
     rating_true,
     rating_pred,
     col_user,
@@ -344,7 +344,7 @@ def precision_at_k(
     Returns:
         float: precision at k (min=0, max=1)
     """
-    _, df_hit, n_users = _merge_ranking_true_pred(
+    _, df_hit, n_users = merge_ranking_true_pred(
         rating_true,
         rating_pred,
         col_user,
@@ -399,7 +399,7 @@ def recall_at_k(
         float: recall at k (min=0, max=1). The maximum value is 1 even when fewer than 
             k items exist for a user in rating_true.
     """
-    rating_true_new, df_hit, n_users = _merge_ranking_true_pred(
+    rating_true_new, df_hit, n_users = merge_ranking_true_pred(
         rating_true,
         rating_pred,
         col_user,
@@ -464,7 +464,7 @@ def ndcg_at_k(
     Returns:
         float: nDCG at k (min=0, max=1).
     """
-    rating_true_new, df_hit, n_users = _merge_ranking_true_pred(
+    rating_true_new, df_hit, n_users = merge_ranking_true_pred(
         rating_true,
         rating_pred,
         col_user,
@@ -545,7 +545,7 @@ def map_at_k(
     Return:
         float: MAP at k (min=0, max=1).
     """
-    rating_true_new, df_hit, n_users = _merge_ranking_true_pred(
+    rating_true_new, df_hit, n_users = merge_ranking_true_pred(
         rating_true,
         rating_pred,
         col_user,

--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -34,6 +34,7 @@ $ python -m ipykernel install --user --name {conda_env} --display-name "Python (
 CHANNELS = [ "defaults", "conda-forge", "pytorch", "fastai"]
 
 CONDA_BASE = {
+    "mock": "mock==2.0.0",
     "dask": "dask>=0.17.1",
     "fastai": "fastai>=1.0.40",
     "fastparquet": "fastparquet>=0.1.6",

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -197,12 +197,11 @@ def test_merge_rating(python_data):
 def test_merge_ranking(python_data):
     ranking_true, ranking_pred, _ = python_data
 
-    ranking_true_pred = merge_ranking_true_pred(
+    ranking_true_pred, data_hit, n_users = merge_ranking_true_pred(
         ranking_true,
         ranking_pred,
         col_user=DEFAULT_USER_COL,
         col_item=DEFAULT_ITEM_COL,
-        col_rating=DEFAULT_RATING_COL,
         col_prediction=PREDICTION_COL,
         relevancy_method="top_k"
     )
@@ -210,8 +209,12 @@ def test_merge_ranking(python_data):
     assert isinstance(ranking_true_pred, pd.DataFrame)
 
     columns = ranking_true_pred.columns
-    columns_exp = [DEFAULT_USER_COL, DEFAULT_ITEM_COL, DEFAULT_RATING_COL, PREDICTION_COL]
+    columns_exp = [DEFAULT_USER_COL, DEFAULT_ITEM_COL, PREDICTION_COL]
     assert set(columns).intersection(set(columns_exp)) is not None
+
+    assert isinstance(data_hit, pd.DataFrame)
+
+    assert isinstance(n_users, int)
 
 
 def test_python_rmse(python_data, target_metrics):

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -105,51 +105,6 @@ def python_data():
     return rating_true, rating_pred, rating_nohit
 
 
-# def test_python_datatypes(python_data):
-#     rating_true, rating_pred, _ = python_data
-#
-#     # Change data types of true and prediction data, and there should type error produced.
-#     rating_true_copy = rating_true.copy()
-#
-#     rating_true_copy[DEFAULT_USER_COL] = rating_true_copy[DEFAULT_USER_COL].astype(str)
-#     rating_true_copy[DEFAULT_RATING_COL] = rating_true_copy[DEFAULT_RATING_COL].astype(str)
-#
-#     with pytest.raises(TypeError) as e_info:
-#         _merge_rating_true_pred(
-#             rating_true_copy,
-#             rating_pred,
-#             col_user=DEFAULT_USER_COL,
-#             col_item=DEFAULT_ITEM_COL,
-#             col_rating=DEFAULT_RATING_COL,
-#             col_prediction=PREDICTION_COL,
-#             relevancy_method="top_k",
-#         )
-#         assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
-#
-#     with pytest.raises(TypeError) as e_info:
-#         _merge_rating_true_pred(
-#             rating_true_copy,
-#             rating_pred,
-#             col_user=DEFAULT_USER_COL,
-#             col_item=DEFAULT_ITEM_COL,
-#             col_rating=DEFAULT_RATING_COL,
-#             col_prediction=PREDICTION_COL,
-#             relevancy_method="top_k",
-#         )
-#         assert str(e_info.value) == "Data types of column {} and {} are different in true and prediction".format(DEFAULT_RATING_COL, PREDICTION_COL)
-#
-#     with pytest.raises(TypeError) as e_info:
-#         _merge_ranking_true_pred(
-#             rating_true_copy,
-#             rating_pred,
-#             col_user=DEFAULT_USER_COL,
-#             col_item=DEFAULT_ITEM_COL,
-#             col_rating=DEFAULT_RATING_COL,
-#             col_prediction=PREDICTION_COL,
-#             relevancy_method="top_k",
-#         )
-#         assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
-
 def test_column_dtypes_match(python_data):
     rating_true, rating_pred, _ = python_data
 

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -12,6 +12,8 @@ from reco_utils.evaluation.python_evaluation import (
     recall_at_k,
     ndcg_at_k,
     map_at_k,
+    _merge_ranking_true_pred,
+    _merge_rating_true_pred
 )
 
 TOL = 0.0001
@@ -93,6 +95,52 @@ def python_data():
         }
     )
     return rating_true, rating_pred, rating_nohit
+
+
+def test_python_datatypes(python_data):
+    rating_true, rating_pred, _ = python_data
+
+    # Change data types of true and prediction data, and there should type error produced.
+    rating_true_copy = rating_true.copy()
+
+    rating_true_copy['userID'] = rating_true_copy['userID'].astype(str)
+    rating_true_copy['rating'] = rating_true_copy['rating'].astype(str)
+
+    with pytest.raises(TypeError) as e_info:
+        _merge_rating_true_pred(
+            rating_true_copy,
+            rating_pred,
+            col_user='userID',
+            col_item='itemID',
+            col_rating='rating',
+            col_prediction='prediction',
+            relevancy_method="top_k",
+        )
+        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format('userID')
+
+    with pytest.raises(TypeError) as e_info:
+        _merge_rating_true_pred(
+            rating_true_copy,
+            rating_pred,
+            col_user='userID',
+            col_item='itemID',
+            col_rating='rating',
+            col_prediction='prediction',
+            relevancy_method="top_k",
+        )
+        assert str(e_info.value) == "Data types of column {} and {} are different in true and prediction".format('rating', 'prediction')
+
+    with pytest.raises(TypeError) as e_info:
+        _merge_ranking_true_pred(
+            rating_true_copy,
+            rating_pred,
+            col_user='userID',
+            col_item='itemID',
+            col_rating='rating',
+            col_prediction='prediction',
+            relevancy_method="top_k",
+        )
+        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format('userID')
 
 
 def test_python_rmse(python_data, target_metrics):

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -3,8 +3,14 @@
 
 import pandas as pd
 import pytest
-from reco_utils.common.constants import *
+from reco_utils.common.constants import (
+    DEFAULT_USER_COL,
+    DEFAULT_ITEM_COL,
+    DEFAULT_RATING_COL,
+    PREDICTION_COL
+)
 from reco_utils.evaluation.python_evaluation import (
+    check_column_dtypes,
     rmse,
     mae,
     rsquared,
@@ -12,9 +18,7 @@ from reco_utils.evaluation.python_evaluation import (
     precision_at_k,
     recall_at_k,
     ndcg_at_k,
-    map_at_k,
-    _merge_ranking_true_pred,
-    _merge_rating_true_pred
+    map_at_k
 )
 
 TOL = 0.0001
@@ -38,16 +42,16 @@ def target_metrics(scope="module"):
 def python_data():
     rating_true = pd.DataFrame(
         {
-            "userID": [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
-            "itemID": [1, 2, 3, 1, 4, 5, 6, 7, 2, 5, 6, 8, 9, 10, 11, 12, 13, 14],
-            "rating": [5, 4, 3, 5, 5, 3, 3, 1, 5, 5, 5, 4, 4, 3, 3, 3, 2, 1],
+            DEFAULT_USER_COL: [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            DEFAULT_ITEM_COL: [1, 2, 3, 1, 4, 5, 6, 7, 2, 5, 6, 8, 9, 10, 11, 12, 13, 14],
+            DEFAULT_RATING_COL: [5, 4, 3, 5, 5, 3, 3, 1, 5, 5, 5, 4, 4, 3, 3, 3, 2, 1],
         }
     )
     rating_pred = pd.DataFrame(
         {
-            "userID": [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
-            "itemID": [3, 10, 12, 10, 3, 5, 11, 13, 4, 10, 7, 13, 1, 3, 5, 2, 11, 14],
-            "prediction": [
+            DEFAULT_USER_COL: [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            DEFAULT_ITEM_COL: [3, 10, 12, 10, 3, 5, 11, 13, 4, 10, 7, 13, 1, 3, 5, 2, 11, 14],
+            PREDICTION_COL: [
                 14,
                 13,
                 12,
@@ -71,9 +75,9 @@ def python_data():
     )
     rating_nohit = pd.DataFrame(
         {
-            "userID": [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
-            "itemID": [100] * rating_pred.shape[0],
-            "prediction": [
+            DEFAULT_USER_COL: [1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
+            DEFAULT_ITEM_COL: [100] * rating_pred.shape[0],
+            PREDICTION_COL: [
                 14,
                 13,
                 12,
@@ -98,7 +102,53 @@ def python_data():
     return rating_true, rating_pred, rating_nohit
 
 
-def test_python_datatypes(python_data):
+# def test_python_datatypes(python_data):
+#     rating_true, rating_pred, _ = python_data
+#
+#     # Change data types of true and prediction data, and there should type error produced.
+#     rating_true_copy = rating_true.copy()
+#
+#     rating_true_copy[DEFAULT_USER_COL] = rating_true_copy[DEFAULT_USER_COL].astype(str)
+#     rating_true_copy[DEFAULT_RATING_COL] = rating_true_copy[DEFAULT_RATING_COL].astype(str)
+#
+#     with pytest.raises(TypeError) as e_info:
+#         _merge_rating_true_pred(
+#             rating_true_copy,
+#             rating_pred,
+#             col_user=DEFAULT_USER_COL,
+#             col_item=DEFAULT_ITEM_COL,
+#             col_rating=DEFAULT_RATING_COL,
+#             col_prediction=PREDICTION_COL,
+#             relevancy_method="top_k",
+#         )
+#         assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
+#
+#     with pytest.raises(TypeError) as e_info:
+#         _merge_rating_true_pred(
+#             rating_true_copy,
+#             rating_pred,
+#             col_user=DEFAULT_USER_COL,
+#             col_item=DEFAULT_ITEM_COL,
+#             col_rating=DEFAULT_RATING_COL,
+#             col_prediction=PREDICTION_COL,
+#             relevancy_method="top_k",
+#         )
+#         assert str(e_info.value) == "Data types of column {} and {} are different in true and prediction".format(DEFAULT_RATING_COL, PREDICTION_COL)
+#
+#     with pytest.raises(TypeError) as e_info:
+#         _merge_ranking_true_pred(
+#             rating_true_copy,
+#             rating_pred,
+#             col_user=DEFAULT_USER_COL,
+#             col_item=DEFAULT_ITEM_COL,
+#             col_rating=DEFAULT_RATING_COL,
+#             col_prediction=PREDICTION_COL,
+#             relevancy_method="top_k",
+#         )
+#         assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
+
+
+def test_check_column_dtypes(python_data):
     rating_true, rating_pred, _ = python_data
 
     # Change data types of true and prediction data, and there should type error produced.
@@ -108,7 +158,7 @@ def test_python_datatypes(python_data):
     rating_true_copy[DEFAULT_RATING_COL] = rating_true_copy[DEFAULT_RATING_COL].astype(str)
 
     with pytest.raises(TypeError) as e_info:
-        _merge_rating_true_pred(
+        rmse(
             rating_true_copy,
             rating_pred,
             col_user=DEFAULT_USER_COL,
@@ -119,35 +169,12 @@ def test_python_datatypes(python_data):
         )
         assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
 
-    with pytest.raises(TypeError) as e_info:
-        _merge_rating_true_pred(
-            rating_true_copy,
-            rating_pred,
-            col_user=DEFAULT_USER_COL,
-            col_item=DEFAULT_ITEM_COL,
-            col_rating=DEFAULT_RATING_COL,
-            col_prediction=PREDICTION_COL,
-            relevancy_method="top_k",
-        )
-        assert str(e_info.value) == "Data types of column {} and {} are different in true and prediction".format(DEFAULT_RATING_COL, PREDICTION_COL)
-
-    with pytest.raises(TypeError) as e_info:
-        _merge_ranking_true_pred(
-            rating_true_copy,
-            rating_pred,
-            col_user=DEFAULT_USER_COL,
-            col_item=DEFAULT_ITEM_COL,
-            col_rating=DEFAULT_RATING_COL,
-            col_prediction=PREDICTION_COL,
-            relevancy_method="top_k",
-        )
-        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
 
 
 def test_python_rmse(python_data, target_metrics):
     rating_true, rating_pred, _ = python_data
     assert (
-        rmse(rating_true=rating_true, rating_pred=rating_true, col_prediction="rating")
+        rmse(rating_true=rating_true, rating_pred=rating_true, col_prediction=DEFAULT_RATING_COL)
         == 0
     )
     assert rmse(rating_true, rating_pred) == target_metrics["rmse"]
@@ -156,7 +183,7 @@ def test_python_rmse(python_data, target_metrics):
 def test_python_mae(python_data, target_metrics):
     rating_true, rating_pred, _ = python_data
     assert (
-        mae(rating_true=rating_true, rating_pred=rating_true, col_prediction="rating")
+        mae(rating_true=rating_true, rating_pred=rating_true, col_prediction=DEFAULT_RATING_COL)
         == 0
     )
     assert mae(rating_true, rating_pred) == target_metrics["mae"]
@@ -166,7 +193,7 @@ def test_python_rsquared(python_data, target_metrics):
     rating_true, rating_pred, _ = python_data
 
     assert rsquared(
-        rating_true=rating_true, rating_pred=rating_true, col_prediction="rating"
+        rating_true=rating_true, rating_pred=rating_true, col_prediction=DEFAULT_RATING_COL
     ) == pytest.approx(1.0, TOL)
     assert rsquared(rating_true, rating_pred) == target_metrics["rsquared"]
 
@@ -175,7 +202,7 @@ def test_python_exp_var(python_data, target_metrics):
     rating_true, rating_pred, _ = python_data
 
     assert exp_var(
-        rating_true=rating_true, rating_pred=rating_true, col_prediction="rating"
+        rating_true=rating_true, rating_pred=rating_true, col_prediction=DEFAULT_RATING_COL
     ) == pytest.approx(1.0, TOL)
     assert exp_var(rating_true, rating_pred) == target_metrics["exp_var"]
 
@@ -188,7 +215,7 @@ def test_python_ndcg_at_k(python_data, target_metrics):
             k=10,
             rating_true=rating_true,
             rating_pred=rating_true,
-            col_prediction="rating",
+            col_prediction=DEFAULT_RATING_COL,
         )
         == 1
     )
@@ -204,7 +231,7 @@ def test_python_map_at_k(python_data, target_metrics):
             k=10,
             rating_true=rating_true,
             rating_pred=rating_true,
-            col_prediction="rating",
+            col_prediction=DEFAULT_RATING_COL,
         )
         == 1
     )
@@ -219,7 +246,7 @@ def test_python_precision(python_data, target_metrics):
             k=10,
             rating_true=rating_true,
             rating_pred=rating_true,
-            col_prediction="rating",
+            col_prediction=DEFAULT_RATING_COL,
         )
         == 0.6
     )
@@ -228,27 +255,27 @@ def test_python_precision(python_data, target_metrics):
 
     # Check normalization
     single_user = pd.DataFrame(
-        {"userID": [1, 1, 1], "itemID": [1, 2, 3], "rating": [5, 4, 3]}
+        {DEFAULT_USER_COL: [1, 1, 1], DEFAULT_ITEM_COL: [1, 2, 3], DEFAULT_RATING_COL: [5, 4, 3]}
     )
     assert (
         precision_at_k(
             k=3,
             rating_true=single_user,
             rating_pred=single_user,
-            col_prediction="rating",
+            col_prediction=DEFAULT_RATING_COL,
         )
         == 1
     )
     same_items = pd.DataFrame(
         {
-            "userID": [1, 1, 1, 2, 2, 2],
-            "itemID": [1, 2, 3, 1, 2, 3],
-            "rating": [5, 4, 3, 5, 5, 3],
+            DEFAULT_USER_COL: [1, 1, 1, 2, 2, 2],
+            DEFAULT_ITEM_COL: [1, 2, 3, 1, 2, 3],
+            DEFAULT_RATING_COL: [5, 4, 3, 5, 5, 3],
         }
     )
     assert (
         precision_at_k(
-            k=3, rating_true=same_items, rating_pred=same_items, col_prediction="rating"
+            k=3, rating_true=same_items, rating_pred=same_items, col_prediction=DEFAULT_RATING_COL
         )
         == 1
     )
@@ -257,7 +284,7 @@ def test_python_precision(python_data, target_metrics):
     # if we do precision@5 when there is only 3 items, we can get a maximum of 3/5.
     assert (
         precision_at_k(
-            k=5, rating_true=same_items, rating_pred=same_items, col_prediction="rating"
+            k=5, rating_true=same_items, rating_pred=same_items, col_prediction=DEFAULT_RATING_COL
         )
         == 0.6
     )
@@ -267,7 +294,7 @@ def test_python_recall(python_data, target_metrics):
     rating_true, rating_pred, rating_nohit = python_data
 
     assert recall_at_k(
-        k=10, rating_true=rating_true, rating_pred=rating_true, col_prediction="rating"
+        k=10, rating_true=rating_true, rating_pred=rating_true, col_prediction=DEFAULT_RATING_COL
     ) == pytest.approx(1, 0.1)
     assert recall_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert recall_at_k(rating_true, rating_pred, k=10) == target_metrics["recall"]
@@ -280,13 +307,13 @@ def test_python_errors(python_data):
         rmse(rating_true, rating_true, col_user="not_user")
 
     with pytest.raises(ValueError):
-        mae(rating_pred, rating_pred, col_rating="prediction", col_user="not_user")
+        mae(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_user="not_user")
 
     with pytest.raises(ValueError):
         rsquared(rating_true, rating_pred, col_item="not_item")
 
     with pytest.raises(ValueError):
-        exp_var(rating_pred, rating_pred, col_rating="prediction", col_item="not_item")
+        exp_var(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_item="not_item")
 
     with pytest.raises(ValueError):
         precision_at_k(rating_true, rating_pred, col_rating="not_rating")
@@ -298,4 +325,4 @@ def test_python_errors(python_data):
         ndcg_at_k(rating_true, rating_true, col_user="not_user")
 
     with pytest.raises(ValueError):
-        map_at_k(rating_pred, rating_pred, col_rating="prediction", col_user="not_user")
+        map_at_k(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_user="not_user")

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -3,6 +3,7 @@
 
 import pandas as pd
 import pytest
+from reco_utils.common.constants import *
 from reco_utils.evaluation.python_evaluation import (
     rmse,
     mae,
@@ -103,44 +104,44 @@ def test_python_datatypes(python_data):
     # Change data types of true and prediction data, and there should type error produced.
     rating_true_copy = rating_true.copy()
 
-    rating_true_copy['userID'] = rating_true_copy['userID'].astype(str)
-    rating_true_copy['rating'] = rating_true_copy['rating'].astype(str)
+    rating_true_copy[DEFAULT_USER_COL] = rating_true_copy[DEFAULT_USER_COL].astype(str)
+    rating_true_copy[DEFAULT_RATING_COL] = rating_true_copy[DEFAULT_RATING_COL].astype(str)
 
     with pytest.raises(TypeError) as e_info:
         _merge_rating_true_pred(
             rating_true_copy,
             rating_pred,
-            col_user='userID',
-            col_item='itemID',
-            col_rating='rating',
-            col_prediction='prediction',
+            col_user=DEFAULT_USER_COL,
+            col_item=DEFAULT_ITEM_COL,
+            col_rating=DEFAULT_RATING_COL,
+            col_prediction=PREDICTION_COL,
             relevancy_method="top_k",
         )
-        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format('userID')
+        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
 
     with pytest.raises(TypeError) as e_info:
         _merge_rating_true_pred(
             rating_true_copy,
             rating_pred,
-            col_user='userID',
-            col_item='itemID',
-            col_rating='rating',
-            col_prediction='prediction',
+            col_user=DEFAULT_USER_COL,
+            col_item=DEFAULT_ITEM_COL,
+            col_rating=DEFAULT_RATING_COL,
+            col_prediction=PREDICTION_COL,
             relevancy_method="top_k",
         )
-        assert str(e_info.value) == "Data types of column {} and {} are different in true and prediction".format('rating', 'prediction')
+        assert str(e_info.value) == "Data types of column {} and {} are different in true and prediction".format(DEFAULT_RATING_COL, PREDICTION_COL)
 
     with pytest.raises(TypeError) as e_info:
         _merge_ranking_true_pred(
             rating_true_copy,
             rating_pred,
-            col_user='userID',
-            col_item='itemID',
-            col_rating='rating',
-            col_prediction='prediction',
+            col_user=DEFAULT_USER_COL,
+            col_item=DEFAULT_ITEM_COL,
+            col_rating=DEFAULT_RATING_COL,
+            col_prediction=PREDICTION_COL,
             relevancy_method="top_k",
         )
-        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format('userID')
+        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
 
 
 def test_python_rmse(python_data, target_metrics):

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -269,6 +269,7 @@ def test_python_precision(python_data, target_metrics):
         )
         == 1
     )
+
     same_items = pd.DataFrame(
         {
             DEFAULT_USER_COL: [1, 1, 1, 2, 2, 2],
@@ -278,7 +279,10 @@ def test_python_precision(python_data, target_metrics):
     )
     assert (
         precision_at_k(
-            k=3, rating_true=same_items, rating_pred=same_items, col_prediction=DEFAULT_RATING_COL
+            k=3,
+            rating_true=same_items,
+            rating_pred=same_items,
+            col_prediction=DEFAULT_RATING_COL
         )
         == 1
     )

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -264,6 +264,7 @@ def test_python_precision(python_data, target_metrics):
             k=3,
             rating_true=single_user,
             rating_pred=single_user,
+            col_rating=DEFAULT_RATING_COL,
             col_prediction=DEFAULT_RATING_COL,
         )
         == 1

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -157,6 +157,7 @@ def test_merge_ranking(python_data):
         ranking_pred,
         col_user=DEFAULT_USER_COL,
         col_item=DEFAULT_ITEM_COL,
+        col_rating=DEFAULT_RATING_COL,
         col_prediction=PREDICTION_COL,
         relevancy_method="top_k"
     )


### PR DESCRIPTION
### Description
The input column data types should be consistent in both the true and prediction dataframes when using the Python evaluator - this is to make sure the join operation before the actual calculation of metrics does not mess up because of mismatch of column data types. 

@miguelgfierro see if there is anything. 

### Related Issues
#543 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.



