### PR TITLE
Prototype of Running Notebooks in AzureML

### DIFF
--- a/.amlignore
+++ b/.amlignore
@@ -1,0 +1,7 @@
+.ipynb_checkpoints
+azureml-logs
+.azureml
+.git
+outputs
+azureml-setup
+docs

--- a/notebooks/02_train_in_the_cloud/train_fastai_on_aml.ipynb
+++ b/notebooks/02_train_in_the_cloud/train_fastai_on_aml.ipynb
@@ -1,0 +1,285 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run a notebook in Azure using AzureML\n",
+    "\n",
+    "This requires an AzureML workspace to be set up. The workspace will be loaded from the configuration using `Workspace.from_config()`. \n",
+    "\n",
+    "Please see [this notebook](https://github.com/Azure/MachineLearningNotebooks/blob/master/configuration.ipynb) on how to create an AzureML workspace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "This notebook was created using version 1.0.8 of the Azure ML SDK\n",
+      "You are currently using version 1.0.15 of the Azure ML SDK\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "sys.path.append(\"../../\")\n",
+    "\n",
+    "import azureml.core\n",
+    "\n",
+    "print(\"This notebook was created using version 1.0.8 of the Azure ML SDK\")\n",
+    "print(\"You are currently using version\", azureml.core.VERSION, \"of the Azure ML SDK\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get the workspace and the experiment to run under (create a new one each day)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found the config file in: /data/home/danielsc/notebooks/Recommenders/config.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "from azureml.core import Workspace\n",
+    "from azureml.core import Experiment\n",
+    "import datetime\n",
+    "\n",
+    "ws = Workspace.from_config()\n",
+    "experiment = Experiment(ws, 'recommender-' + datetime.datetime.now().strftime(\"%Y-%m-%d\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Making sure the yaml file defining the environment is present"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated conda file: reco_base.yaml\r\n",
+      "\r\n",
+      "To create the conda environment:\r\n",
+      "$ conda env create -f reco_base.yaml\r\n",
+      "\r\n",
+      "To update the conda environment:\r\n",
+      "$ conda env update -f reco_base.yaml\r\n",
+      "\r\n",
+      "To register the conda environment in Jupyter:\r\n",
+      "$ conda activate reco_base\r\n",
+      "$ python -m ipykernel install --user --name reco_base --display-name \"Python (reco_base)\"\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!(cd ../.. && {sys.executable} scripts/generate_conda_file.py)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up the job to run the notebook\n",
+    "For the environment we use the reco_base.yaml. Due to [this bug](https://msdata.visualstudio.com/Vienna/_workitems/edit/377078), the compute target needs to be DSVM right now, so you need to attach a DSVM to your workspace -- mine is called `\"lidsvm\"`.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"width:100%\"><tr><th>Experiment</th><th>Id</th><th>Type</th><th>Status</th><th>Details Page</th><th>Docs Page</th></tr><tr><td>recommender-2019-02-23</td><td>recommender-2019-02-23_1550966125_c6b27450</td><td>azureml.scriptrun</td><td>Running</td><td><a href=\"https://mlworkspace.azure.ai/portal/subscriptions/15ae9cb6-95c1-483d-a0e3-b1a1a3b06324/resourceGroups/recommender/providers/Microsoft.MachineLearningServices/workspaces/recommender/experiments/recommender-2019-02-23/runs/recommender-2019-02-23_1550966125_c6b27450\" target=\"_blank\" rel=\"noopener\">Link to Azure Portal</a></td><td><a href=\"https://docs.microsoft.com/en-us/python/api/azureml-core/azureml.core.script_run.ScriptRun?view=azure-ml-py\" target=\"_blank\" rel=\"noopener\">Link to Documentation</a></td></tr></table>"
+      ],
+      "text/plain": [
+       "Run(Experiment: recommender-2019-02-23,\n",
+       "Id: recommender-2019-02-23_1550966125_c6b27450,\n",
+       "Type: azureml.scriptrun,\n",
+       "Status: Preparing)"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from azureml.core.runconfig import RunConfiguration\n",
+    "from azureml.core.conda_dependencies import CondaDependencies\n",
+    "from azureml.core.runconfig import DEFAULT_CPU_IMAGE\n",
+    "from azureml.core.script_run_config import ScriptRunConfig\n",
+    "\n",
+    "run_config = RunConfiguration()\n",
+    "run_config.target = \"lidsvm\"\n",
+    "run_config.environment.docker.enabled = True\n",
+    "run_config.environment.docker.base_image = DEFAULT_CPU_IMAGE\n",
+    "run_config.environment.python.user_managed_dependencies = False\n",
+    "run_config.auto_prepare_environment = True\n",
+    "run_config.environment.python.conda_dependencies = CondaDependencies(conda_dependencies_file_path='../../reco_base.yaml')\n",
+    "\n",
+    "script_run_config = ScriptRunConfig(source_directory='../../',\n",
+    "                                    script='scripts/notebook_launcher.py',\n",
+    "                                    arguments=['--notebook_path', 'notebooks/00_quick_start/fastai_movielens.ipynb', 'MOVIELENS_DATA_SIZE', '100k'],\n",
+    "                                    run_config=run_config)\n",
+    "\n",
+    "run = experiment.submit(script_run_config)\n",
+    "\n",
+    "run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd4caded81d646d9b2ee4c9f342af7aa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "_UserRunWidget(widget_settings={'childWidgetDisplay': 'popup', 'send_telemetry': False, 'log_level': 'INFO', '…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from azureml.widgets import RunDetails\n",
+    "RunDetails(run).show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['azureml-logs/60_control_log.txt',\n",
+       " 'azureml-logs/80_driver_log.txt',\n",
+       " 'azureml-logs/azureml.log',\n",
+       " 'driver_log',\n",
+       " 'outputs/output.ipynb']"
+      ]
+     },
+     "execution_count": 128,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "run.get_file_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "import sys\r\n",
+      "import os\r\n",
+      "import papermill as pm\r\n",
+      "import argparse\r\n",
+      "from azureml.core import Run\r\n",
+      "\r\n",
+      "os.system(sys.executable + ' -m ipykernel install --user --name ipyazureml')\r\n",
+      "\r\n",
+      "def execute_notebook(notebook_path, parameters):\r\n",
+      "    pm.execute_notebook(\r\n",
+      "        notebook_path,\r\n",
+      "        'outputs/output.ipynb',\r\n",
+      "        kernel_name='ipyazureml',\r\n",
+      "        parameters=parameters,\r\n",
+      "    )\r\n",
+      "    results = pm.read_notebook('outputs/output.ipynb').dataframe.set_index(\"name\")[\"value\"]\r\n",
+      "\r\n",
+      "    run = Run.get_context()\r\n",
+      "    for key, value in results.items():\r\n",
+      "        run.log(key, value)\r\n",
+      "            \r\n",
+      "    return results\r\n",
+      "\r\n",
+      "\r\n",
+      "if __name__ == '__main__':\r\n",
+      "    parser = argparse.ArgumentParser()\r\n",
+      "    parser.add_argument('--notebook_path')\r\n",
+      "    FLAGS, unparsed = parser.parse_known_args()\r\n",
+      "\r\n",
+      "    parameters= {unparsed[i]: unparsed[i+1] for i in range(0, len(unparsed), 2)}\r\n",
+      "    print(FLAGS.notebook_path, parameters)\r\n",
+      "    execute_notebook(notebook_path = FLAGS.notebook_path, \r\n",
+      "                       parameters=parameters)\r\n",
+      "\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!cat ../../scripts/notebook_launcher.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (azureml)",
+   "language": "python",
+   "name": "azureml"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -34,6 +34,7 @@ $ python -m ipykernel install --user --name {conda_env} --display-name "Python (
 CHANNELS = ["conda-forge", "pytorch", "fastai", "defaults"]
 
 CONDA_BASE = {
+    "python": "python==3.6.8",
     "dask": "dask>=0.17.1",
     "fastai": "fastai>=1.0.40",
     "fastparquet": "fastparquet>=0.1.6",
@@ -44,7 +45,6 @@ CONDA_BASE = {
     "numpy": "numpy>=1.13.3",
     "pandas": "pandas>=0.23.4",
     "pymongo": "pymongo>=3.6.1",
-    "python": "python==3.6.8",
     "pytest": "pytest>=3.6.4",
     "pytorch": "pytorch-cpu>=1.0.0",
     "seaborn": "seaborn>=0.8.1",

--- a/scripts/notebook_launcher.py
+++ b/scripts/notebook_launcher.py
@@ -1,0 +1,35 @@
+import sys
+import os
+import papermill as pm
+import argparse
+from azureml.core import Run
+
+os.system(sys.executable + ' -m ipykernel install --user --name ipyazureml')
+
+def execute_notebook(notebook_path, parameters):
+    pm.execute_notebook(
+        notebook_path,
+        'outputs/output.ipynb',
+        kernel_name='ipyazureml',
+        parameters=parameters,
+    )
+    results = pm.read_notebook('outputs/output.ipynb').dataframe.set_index("name")["value"]
+
+    run = Run.get_context()
+    for key, value in results.items():
+        run.log(key, value)
+            
+    return results
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--notebook_path')
+    FLAGS, unparsed = parser.parse_known_args()
+
+    parameters= {unparsed[i]: unparsed[i+1] for i in range(0, len(unparsed), 2)}
+    print(FLAGS.notebook_path, parameters)
+    execute_notebook(notebook_path = FLAGS.notebook_path, 
+                       parameters=parameters)
+
+


### PR DESCRIPTION
### Description
**This PR is just for discussion purposes, not meant to be merged in.**
The PR is showing a prototype of how a user can run a notebook without any changes on AzureML using papermill. The main action is happening [in this notebook](https://github.com/Microsoft/Recommenders/blob/danielsc/azureml/notebooks/02_train_in_the_cloud/train_fastai_on_aml.ipynb) and [this wrapper script](https://github.com/Microsoft/Recommenders/blob/danielsc/azureml/scripts/notebook_launcher.py). 
Things to note:
1. Due to [this bug](https://msdata.visualstudio.com/Vienna/_workitems/edit/377078), the compute target needs to be DSVM right now. After this has been fixed, the same should work on AML Compute
2. Due to [this bug](https://msdata.visualstudio.com/Vienna/_workitems/edit/377077), I had to change the order of the dependencies in the yaml file generation -- don't ask... it is already fixed, but will take time to be rolled out.
2. In this prototype, the parameter passing goes over the command line, which restricts us to strings. Setting TOP_K to 10 would fail. In the product implementation we should preserve the types.
3. The output parameters of the notebook are nicely written to run history and the output notebook is uploaded since it is written to ./outputs. However, it is only uploaded after the job completes. For the product implementation, we should think about uploading it while the job is still running and about visualizing it in the widget or workspace UX.
4. I am not happy with the amount of code that is required to set up a custom conda environment. We should look at making that easier/more compact in AML.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



