### PR TITLE
added abs tolerance

### DIFF
--- a/tests/integration/test_notebooks_gpu.py
+++ b/tests/integration/test_notebooks_gpu.py
@@ -8,6 +8,7 @@ from reco_utils.common.gpu_utils import get_number_gpus
 from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
 
 TOL = 0.5
+ABS_TOL = 0.05
 
 
 @pytest.mark.integration
@@ -47,7 +48,7 @@ def test_ncf_integration(notebooks, size, epochs, expected_values):
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.integration
@@ -87,7 +88,7 @@ def test_ncf_deep_dive_integration(
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.integration
@@ -124,7 +125,7 @@ def test_fastai_integration(notebooks, size, epochs, expected_values):
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.integration
@@ -145,31 +146,28 @@ def test_fastai_integration(notebooks, size, epochs, expected_values):
                 "precision_at_k": 0.063195,
                 "recall_at_k": 0.020235,
             },
-        ),
+        )
     ],
 )
 def test_wide_deep(notebooks, size, epochs, expected_values):
     notebook_path = notebooks["wide_deep"]
 
-    MODEL_DIR = 'model_checkpoints'
+    MODEL_DIR = "model_checkpoints"
     params = {
-        'MOVIELENS_DATA_SIZE': size,
-        'EPOCHS': epochs,
-        'EVALUATE_WHILE_TRAINING': False,
-        'MODEL_DIR': MODEL_DIR,
-        'EXPORT_DIR_BASE': MODEL_DIR,
-        'RATING_METRICS': ['rmse', 'mae', 'rsquared', 'exp_var'],
-        'RANKING_METRICS': ['ndcg_at_k', 'map_at_k', 'precision_at_k', 'recall_at_k'],
+        "MOVIELENS_DATA_SIZE": size,
+        "EPOCHS": epochs,
+        "EVALUATE_WHILE_TRAINING": False,
+        "MODEL_DIR": MODEL_DIR,
+        "EXPORT_DIR_BASE": MODEL_DIR,
+        "RATING_METRICS": ["rmse", "mae", "rsquared", "exp_var"],
+        "RANKING_METRICS": ["ndcg_at_k", "map_at_k", "precision_at_k", "recall_at_k"],
     }
     pm.execute_notebook(
-        notebook_path,
-        OUTPUT_NOTEBOOK,
-        kernel_name=KERNEL_NAME,
-        parameters=params,
+        notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME, parameters=params
     )
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
     shutil.rmtree(MODEL_DIR, ignore_errors=True)

--- a/tests/integration/test_notebooks_pyspark.py
+++ b/tests/integration/test_notebooks_pyspark.py
@@ -8,6 +8,7 @@ from reco_utils.common.spark_utils import start_or_get_spark
 
 
 TOL = 0.05
+ABS_TOL = 0.05
 
 
 @pytest.mark.spark
@@ -24,11 +25,11 @@ def test_als_pyspark_integration(notebooks):
     results = nb.dataframe.set_index("name")["value"]
     start_or_get_spark("ALS PySpark").stop()
 
-    assert results["map"] == pytest.approx(0.00201, rel=TOL)
-    assert results["ndcg"] == pytest.approx(0.02516, rel=TOL)
-    assert results["precision"] == pytest.approx(0.03172, rel=TOL)
-    assert results["recall"] == pytest.approx(0.009302, rel=TOL)
-    assert results["rmse"] == pytest.approx(0.8621, rel=TOL)
-    assert results["mae"] == pytest.approx(0.68023, rel=TOL)
-    assert results["exp_var"] == pytest.approx(0.4094, rel=TOL)
-    assert results["rsquared"] == pytest.approx(0.4038, rel=TOL)
+    assert results["map"] == pytest.approx(0.00201, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.02516, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.03172, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.009302, rel=TOL, abs=ABS_TOL)
+    assert results["rmse"] == pytest.approx(0.8621, rel=TOL, abs=ABS_TOL)
+    assert results["mae"] == pytest.approx(0.68023, rel=TOL, abs=ABS_TOL)
+    assert results["exp_var"] == pytest.approx(0.4094, rel=TOL, abs=ABS_TOL)
+    assert results["rsquared"] == pytest.approx(0.4038, rel=TOL, abs=ABS_TOL)

--- a/tests/integration/test_notebooks_python.py
+++ b/tests/integration/test_notebooks_python.py
@@ -7,6 +7,7 @@ from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
 
 
 TOL = 0.05
+ABS_TOL = 0.05
 
 
 @pytest.mark.integration
@@ -23,14 +24,14 @@ TOL = 0.05
             },
         ),
         (
-            "10m", 
+            "10m",
             {
-                "map": 0.101402, 
-                "ndcg": 0.321073, 
-                "precision": 0.275766, 
-                "recall": 0.156483
-            }
-        ) 
+                "map": 0.101402,
+                "ndcg": 0.321073,
+                "precision": 0.275766,
+                "recall": 0.156483,
+            },
+        ),
     ],
 )
 def test_sar_single_node_integration(notebooks, size, expected_values):
@@ -44,7 +45,7 @@ def test_sar_single_node_integration(notebooks, size, expected_values):
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.integration
@@ -75,7 +76,7 @@ def test_baseline_deep_dive_integration(notebooks, size, expected_values):
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.integration
@@ -109,7 +110,7 @@ def test_surprise_svd_integration(notebooks, size, expected_values):
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.integration
@@ -142,4 +143,4 @@ def test_vw_deep_dive_integration(notebooks, size, expected_values):
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
     for key, value in expected_values.items():
-        assert results[key] == pytest.approx(value, rel=TOL)
+        assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)

--- a/tests/smoke/test_notebooks_pyspark.py
+++ b/tests/smoke/test_notebooks_pyspark.py
@@ -8,6 +8,7 @@ from reco_utils.common.spark_utils import start_or_get_spark
 
 
 TOL = 0.05
+ABS_TOL = 0.05
 
 
 @pytest.mark.smoke
@@ -24,11 +25,11 @@ def test_als_pyspark_smoke(notebooks):
     results = nb.dataframe.set_index("name")["value"]
     start_or_get_spark("ALS PySpark").stop()
 
-    assert results["map"] == pytest.approx(0.0052, rel=TOL)
-    assert results["ndcg"] == pytest.approx(0.0463, rel=TOL)
-    assert results["precision"] == pytest.approx(0.0487, rel=TOL)
-    assert results["recall"] == pytest.approx(0.0177, rel=TOL)
-    assert results["rmse"] == pytest.approx(0.9636, rel=TOL)
-    assert results["mae"] == pytest.approx(0.7508, rel=TOL)
-    assert results["exp_var"] == pytest.approx(0.2672, rel=TOL)
-    assert results["rsquared"] == pytest.approx(0.2611, rel=TOL)
+    assert results["map"] == pytest.approx(0.0052, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.0463, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.0487, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.0177, rel=TOL, abs=ABS_TOL)
+    assert results["rmse"] == pytest.approx(0.9636, rel=TOL, abs=ABS_TOL)
+    assert results["mae"] == pytest.approx(0.7508, rel=TOL, abs=ABS_TOL)
+    assert results["exp_var"] == pytest.approx(0.2672, rel=TOL, abs=ABS_TOL)
+    assert results["rsquared"] == pytest.approx(0.2611, rel=TOL, abs=ABS_TOL)

--- a/tests/smoke/test_notebooks_python.py
+++ b/tests/smoke/test_notebooks_python.py
@@ -7,6 +7,7 @@ from tests.notebooks_common import OUTPUT_NOTEBOOK, KERNEL_NAME
 
 
 TOL = 0.05
+ABS_TOL = 0.05
 
 
 @pytest.mark.smoke
@@ -21,10 +22,10 @@ def test_sar_single_node_smoke(notebooks):
     )
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
-    assert results["map"] == pytest.approx(0.105815262, TOL)
-    assert results["ndcg"] == pytest.approx(0.373197255, TOL)
-    assert results["precision"] == pytest.approx(0.326617179, TOL)
-    assert results["recall"] == pytest.approx(0.175956743, TOL)
+    assert results["map"] == pytest.approx(0.105815262, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.373197255, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.326617179, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.175956743, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.smoke
@@ -39,14 +40,14 @@ def test_baseline_deep_dive_smoke(notebooks):
     )
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
-    assert results["rmse"] == pytest.approx(1.054252, TOL)
-    assert results["mae"] == pytest.approx(0.846033, TOL)
-    assert results["rsquared"] == pytest.approx(0.136435, TOL)
-    assert results["exp_var"] == pytest.approx(0.136446, TOL)
-    assert results["map"] == pytest.approx(0.052850, TOL)
-    assert results["ndcg"] == pytest.approx(0.248061, TOL)
-    assert results["precision"] == pytest.approx(0.223754, TOL)
-    assert results["recall"] == pytest.approx(0.108826, TOL)
+    assert results["rmse"] == pytest.approx(1.054252, rel=TOL, abs=ABS_TOL)
+    assert results["mae"] == pytest.approx(0.846033, rel=TOL, abs=ABS_TOL)
+    assert results["rsquared"] == pytest.approx(0.136435, rel=TOL, abs=ABS_TOL)
+    assert results["exp_var"] == pytest.approx(0.136446, rel=TOL, abs=ABS_TOL)
+    assert results["map"] == pytest.approx(0.052850, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.248061, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.223754, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.108826, rel=TOL, abs=ABS_TOL)
 
 
 @pytest.mark.smoke
@@ -61,14 +62,14 @@ def test_surprise_svd_smoke(notebooks):
     )
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
-    assert results["rmse"] == pytest.approx(0.96, TOL)
-    assert results["mae"] == pytest.approx(0.75, TOL)
-    assert results["rsquared"] == pytest.approx(0.29, TOL)
-    assert results["exp_var"] == pytest.approx(0.29, TOL)
-    assert results["map"] == pytest.approx(0.013, TOL)
-    assert results["ndcg"] == pytest.approx(0.1, TOL)
-    assert results["precision"] == pytest.approx(0.095, TOL)
-    assert results["recall"] == pytest.approx(0.032, TOL)
+    assert results["rmse"] == pytest.approx(0.96, rel=TOL, abs=ABS_TOL)
+    assert results["mae"] == pytest.approx(0.75, rel=TOL, abs=ABS_TOL)
+    assert results["rsquared"] == pytest.approx(0.29, rel=TOL, abs=ABS_TOL)
+    assert results["exp_var"] == pytest.approx(0.29, rel=TOL, abs=ABS_TOL)
+    assert results["map"] == pytest.approx(0.013, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.1, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.095, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.032, rel=TOL, abs=ABS_TOL)
 
 
 def test_vw_deep_dive_smoke(notebooks):
@@ -82,11 +83,11 @@ def test_vw_deep_dive_smoke(notebooks):
     )
     results = pm.read_notebook(OUTPUT_NOTEBOOK).dataframe.set_index("name")["value"]
 
-    assert results["rmse"] == pytest.approx(0.99575, TOL)
-    assert results["mae"] == pytest.approx(0.72024, TOL)
-    assert results["rsquared"] == pytest.approx(0.22961, TOL)
-    assert results["exp_var"] == pytest.approx(0.22967, TOL)
-    assert results["map"] == pytest.approx(0.25684, TOL)
-    assert results["ndcg"] == pytest.approx(0.65339, TOL)
-    assert results["precision"] == pytest.approx(0.514738, TOL)
-    assert results["recall"] == pytest.approx(0.25684, TOL)
+    assert results["rmse"] == pytest.approx(0.99575, rel=TOL, abs=ABS_TOL)
+    assert results["mae"] == pytest.approx(0.72024, rel=TOL, abs=ABS_TOL)
+    assert results["rsquared"] == pytest.approx(0.22961, rel=TOL, abs=ABS_TOL)
+    assert results["exp_var"] == pytest.approx(0.22967, rel=TOL, abs=ABS_TOL)
+    assert results["map"] == pytest.approx(0.25684, rel=TOL, abs=ABS_TOL)
+    assert results["ndcg"] == pytest.approx(0.65339, rel=TOL, abs=ABS_TOL)
+    assert results["precision"] == pytest.approx(0.514738, rel=TOL, abs=ABS_TOL)
+    assert results["recall"] == pytest.approx(0.25684, rel=TOL, abs=ABS_TOL)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Added abs tolerance in the smoke and integration tests.

This is to prevent the test to fail when there is a high variability in some of the tests with very small metrics (in the order of 0.00x

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.



