### PR TITLE
fix link to deepdive notebook in sar quickstart

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -50,6 +50,8 @@ They have write access to the repo and provide support reviewing issues and pull
     * Reco utils
     * Continuous integration build / test setup
     * Quickstart, deep dive, algorithm comparison, notebooks
+* **[Yassine Khelifi](https://github.com/datashinob)**
+    * SAR notebook quickstart
 
 Contributors
 ------------

--- a/notebooks/00_quick_start/sar_movielens.ipynb
+++ b/notebooks/00_quick_start/sar_movielens.ipynb
@@ -281,7 +281,7 @@
     "\n",
     "Recommendations are achieved by multiplying the affinity matrix $A$ and the similarity matrix $S$. The result is a ***recommendation score matrix*** $R$. We compute the ***top-k*** results for each user in the `recommend_k_items` function seen below.\n",
     "\n",
-    "A full walkthrough of the SAR algorithm can be found [here](../02_modeling/sar_educational_walkthrough.ipynb)."
+    "A full walkthrough of the SAR algorithm can be found [here](../02_model/sar_deep_dive.ipynb)."
    ]
   },
   {
@@ -608,7 +608,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
minor change in 00quickstart/00_quick_start/sar_movielens.ipynb
- fix link to sar deepdive notebook
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ x] I have added tests.
- [ x] I have updated the documentation accordingly.



