### PR TITLE
SPLITTER: remove redundant column

### DIFF
--- a/reco_utils/dataset/python_splitters.py
+++ b/reco_utils/dataset/python_splitters.py
@@ -35,7 +35,10 @@ def python_random_split(data, ratio=0.75, seed=42):
     multi_split, ratio = process_split_ratio(ratio)
 
     if multi_split:
-        return split_pandas_data_with_ratios(data, ratio, shuffle=True, seed=seed)
+        splits = split_pandas_data_with_ratios(data, ratio, shuffle=True, seed=seed)
+        splits_new = [x.drop('split_index', axis=1) for x in splits]
+
+        return splits_new
     else:
         return sk_split(data, test_size=None, train_size=ratio, random_state=seed)
 

--- a/tests/unit/test_python_splitter.py
+++ b/tests/unit/test_python_splitter.py
@@ -157,6 +157,9 @@ def test_random_splitter(test_specs, python_dataset):
         1 - test_specs["ratio"], test_specs["tolerance"]
     )
 
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
+
     splits = python_random_split(
         python_dataset, ratio=test_specs["ratios"], seed=test_specs["seed"]
     )
@@ -171,6 +174,9 @@ def test_random_splitter(test_specs, python_dataset):
     assert len(splits[2]) / test_specs["number_of_rows"] == pytest.approx(
         test_specs["ratios"][2], test_specs["tolerance"]
     )
+
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
 
     splits = python_random_split(
         python_dataset, ratio=test_specs["split_numbers"], seed=test_specs["seed"]
@@ -187,6 +193,9 @@ def test_random_splitter(test_specs, python_dataset):
         test_specs["ratios"][2], test_specs["tolerance"]
     )
 
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
+
 
 def test_chrono_splitter(test_specs, python_dataset):
     splits = python_chrono_split(
@@ -199,6 +208,9 @@ def test_chrono_splitter(test_specs, python_dataset):
     assert len(splits[1]) / test_specs["number_of_rows"] == pytest.approx(
         1 - test_specs["ratio"], test_specs["tolerance"]
     )
+
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
 
     # Test if both contains the same user list. This is because chrono split is stratified.
     users_train = splits[0][DEFAULT_USER_COL].unique()
@@ -240,6 +252,9 @@ def test_chrono_splitter(test_specs, python_dataset):
     assert len(splits[2]) / test_specs["number_of_rows"] == pytest.approx(
         test_specs["ratios"][2], test_specs["tolerance"]
     )
+
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
 
     # Test if all splits contain the same user list. This is because chrono split is stratified.
     users_train = splits[0][DEFAULT_USER_COL].unique()
@@ -298,6 +313,9 @@ def test_stratified_splitter(test_specs, python_dataset):
         1 - test_specs["ratio"], test_specs["tolerance"]
     )
 
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
+
     # Test if both contains the same user list. This is because stratified split is stratified.
     users_train = splits[0][DEFAULT_USER_COL].unique()
     users_test = splits[1][DEFAULT_USER_COL].unique()
@@ -318,6 +336,9 @@ def test_stratified_splitter(test_specs, python_dataset):
     assert len(splits[2]) / test_specs["number_of_rows"] == pytest.approx(
         test_specs["ratios"][2], test_specs["tolerance"]
     )
+
+    for split in splits:
+        assert set(split.columns) == set(python_dataset.columns)
 
 
 def test_int_numpy_stratified_splitter(test_specs, python_int_dataset):


### PR DESCRIPTION
### Description
Remove `split_index` column generated from the intermediate step.

### Related Issues
#614 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



