### PR TITLE
Gramhagen/sar move remove seen

### DIFF
--- a/notebooks/00_quick_start/sar_movielens.ipynb
+++ b/notebooks/00_quick_start/sar_movielens.ipynb
@@ -264,8 +264,11 @@
     "                    format='%(asctime)s %(levelname)-8s %(message)s')\n",
     "\n",
     "model = SARSingleNode(\n",
-    "    remove_seen=True, similarity_type=\"jaccard\", \n",
-    "    time_decay_coefficient=30, time_now=None, timedecay_formula=True, **header\n",
+    "    similarity_type=\"jaccard\", \n",
+    "    time_decay_coefficient=30, \n",
+    "    time_now=None, \n",
+    "    timedecay_formula=True, \n",
+    "    **header\n",
     ")"
    ]
   },
@@ -345,7 +348,7 @@
    "source": [
     "start_time = time.time()\n",
     "\n",
-    "top_k = model.recommend_k_items(test)\n",
+    "top_k = model.recommend_k_items(test, remove_seen=True)\n",
     "\n",
     "test_time = time.time() - start_time\n",
     "print(\"Took {} seconds for prediction.\".format(test_time))\n",
@@ -433,7 +436,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -526,56 +529,32 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/papermill.record+json": {
-       "map": 0.10581526176416436
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "ndcg": 0.373197254984399
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "precision": 0.3266171792152704
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "recall": 0.17595674338464226
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "train_time": 0.5787224769592285
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/papermill.record+json": {
-       "test_time": 0.06923317909240723
-      }
-     },
+     "data": {},
      "metadata": {},
      "output_type": "display_data"
     }

--- a/notebooks/00_quick_start/sar_movielens.ipynb
+++ b/notebooks/00_quick_start/sar_movielens.ipynb
@@ -273,7 +273,7 @@
     "\n",
     "Recommendations are achieved by multiplying the affinity matrix $A$ and the similarity matrix $S$. The result is a ***recommendation score matrix*** $R$. We compute the ***top-k*** results for each user in the `recommend_k_items` function seen below.\n",
     "\n",
-    "A full walkthrough of the SAR algorithm can be found [here](../02_modeling/sar_educational_walkthrough.ipynb)."
+    "A full walkthrough of the SAR algorithm can be found [here](../02_model/sar_deep_dive.ipynb)."
    ]
   },
   {

--- a/notebooks/00_quick_start/sar_movielens.ipynb
+++ b/notebooks/00_quick_start/sar_movielens.ipynb
@@ -48,8 +48,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "System version: 3.6.7 | packaged by conda-forge | (default, Nov 21 2018, 03:09:43) \n",
-      "[GCC 7.3.0]\n",
+      "System version: 3.6.8 |Anaconda, Inc.| (default, Feb 11 2019, 15:03:47) [MSC v.1915 64 bit (AMD64)]\n",
       "Pandas version: 0.24.1\n"
      ]
     }
@@ -139,10 +138,10 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>UserId</th>\n",
-       "      <th>MovieId</th>\n",
-       "      <th>Rating</th>\n",
-       "      <th>Timestamp</th>\n",
+       "      <th>userID</th>\n",
+       "      <th>itemID</th>\n",
+       "      <th>rating</th>\n",
+       "      <th>timestamp</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -186,12 +185,12 @@
        "</div>"
       ],
       "text/plain": [
-       "   UserId  MovieId  Rating  Timestamp\n",
-       "0     196      242     3.0  881250949\n",
-       "1     186      302     3.0  891717742\n",
-       "2      22      377     1.0  878887116\n",
-       "3     244       51     2.0  880606923\n",
-       "4     166      346     1.0  886397596"
+       "   userID  itemID  rating  timestamp\n",
+       "0     196     242     3.0  881250949\n",
+       "1     186     302     3.0  891717742\n",
+       "2      22     377     1.0  878887116\n",
+       "3     244      51     2.0  880606923\n",
+       "4     166     346     1.0  886397596"
       ]
      },
      "execution_count": 3,
@@ -285,23 +284,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-02-05 13:19:22,533 INFO     Collecting user affinity matrix\n",
-      "2019-02-05 13:19:22,538 INFO     Calculating time-decayed affinities\n",
-      "2019-02-05 13:19:22,589 INFO     Creating index columns\n",
-      "2019-02-05 13:19:22,607 INFO     Building user affinity sparse matrix\n",
-      "2019-02-05 13:19:22,615 INFO     Calculating item co-occurrence\n",
-      "2019-02-05 13:19:22,807 INFO     Calculating item similarity\n",
-      "2019-02-05 13:19:22,808 INFO     Calculating jaccard\n",
-      "2019-02-05 13:19:22,991 INFO     Calculating recommendation scores\n",
-      "2019-02-05 13:19:23,106 INFO     Removing seen items\n",
-      "2019-02-05 13:19:23,107 INFO     Done training\n"
+      "2019-03-07 11:33:34,440 INFO     Collecting user affinity matrix\n",
+      "2019-03-07 11:33:34,451 INFO     Calculating time-decayed affinities\n",
+      "2019-03-07 11:33:34,726 INFO     Creating index columns\n",
+      "2019-03-07 11:33:34,762 INFO     Building user affinity sparse matrix\n",
+      "2019-03-07 11:33:34,773 INFO     Calculating item co-occurrence\n",
+      "2019-03-07 11:33:35,048 INFO     Calculating item similarity\n",
+      "2019-03-07 11:33:35,054 INFO     Calculating jaccard\n",
+      "2019-03-07 11:33:35,275 INFO     Done training\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Took 0.5787224769592285 seconds for training.\n"
+      "Took 0.8455877304077148 seconds for training.\n"
      ]
     }
    ],
@@ -323,14 +320,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-02-05 13:19:23,125 INFO     Getting top K\n"
+      "2019-03-07 11:33:35,294 INFO     Calculating recommendation scores\n",
+      "2019-03-07 11:33:35,481 INFO     Removing seen items\n",
+      "2019-03-07 11:33:35,502 INFO     Getting top K\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Took 0.06923317909240723 seconds for prediction.\n"
+      "Took 0.28716468811035156 seconds for prediction.\n"
      ]
     }
    ],
@@ -371,57 +370,57 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>UserId</th>\n",
-       "      <th>MovieId</th>\n",
+       "      <th>userID</th>\n",
+       "      <th>itemID</th>\n",
        "      <th>prediction</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>600</td>\n",
-       "      <td>69</td>\n",
-       "      <td>12.984131</td>\n",
+       "      <td>877</td>\n",
+       "      <td>153</td>\n",
+       "      <td>2.311135</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>600</td>\n",
-       "      <td>183</td>\n",
-       "      <td>13.106912</td>\n",
+       "      <td>877</td>\n",
+       "      <td>234</td>\n",
+       "      <td>2.311886</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>600</td>\n",
-       "      <td>89</td>\n",
-       "      <td>13.163791</td>\n",
+       "      <td>877</td>\n",
+       "      <td>238</td>\n",
+       "      <td>2.315627</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>600</td>\n",
-       "      <td>423</td>\n",
-       "      <td>12.991756</td>\n",
+       "      <td>877</td>\n",
+       "      <td>168</td>\n",
+       "      <td>2.393810</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>600</td>\n",
-       "      <td>144</td>\n",
-       "      <td>13.489795</td>\n",
+       "      <td>877</td>\n",
+       "      <td>97</td>\n",
+       "      <td>2.410769</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   UserId  MovieId  prediction\n",
-       "0     600       69   12.984131\n",
-       "1     600      183   13.106912\n",
-       "2     600       89   13.163791\n",
-       "3     600      423   12.991756\n",
-       "4     600      144   13.489795"
+       "   userID  itemID  prediction\n",
+       "0     877     153    2.311135\n",
+       "1     877     234    2.311886\n",
+       "2     877     238    2.315627\n",
+       "3     877     168    2.393810\n",
+       "4     877      97    2.410769"
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -484,10 +483,10 @@
      "text": [
       "Model:\tsar_ref\n",
       "Top K:\t10\n",
-      "MAP:\t0.105815\n",
-      "NDCG:\t0.373197\n",
-      "Precision@K:\t0.326617\n",
-      "Recall@K:\t0.175957\n"
+      "MAP:\t0.104852\n",
+      "NDCG:\t0.370487\n",
+      "Precision@K:\t0.321125\n",
+      "Recall@K:\t0.174170\n"
      ]
     }
    ],
@@ -506,32 +505,56 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {},
+     "data": {
+      "application/papermill.record+json": {
+       "map": 0.10485162234730652
+      }
+     },
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {},
+     "data": {
+      "application/papermill.record+json": {
+       "ndcg": 0.3704872048540983
+      }
+     },
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {},
+     "data": {
+      "application/papermill.record+json": {
+       "precision": 0.3211252653927813
+      }
+     },
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {},
+     "data": {
+      "application/papermill.record+json": {
+       "recall": 0.17416985459670545
+      }
+     },
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {},
+     "data": {
+      "application/papermill.record+json": {
+       "train_time": 0.8455877304077148
+      }
+     },
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "data": {},
+     "data": {
+      "application/papermill.record+json": {
+       "test_time": 0.28716468811035156
+      }
+     },
      "metadata": {},
      "output_type": "display_data"
     }
@@ -550,9 +573,9 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python (reco)",
+   "display_name": "Python (reco_base)",
    "language": "python",
-   "name": "reco"
+   "name": "reco_base"
   },
   "language_info": {
    "codemirror_mode": {
@@ -564,7 +587,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/00_quick_start/sar_movielens.ipynb
+++ b/notebooks/00_quick_start/sar_movielens.ipynb
@@ -59,9 +59,7 @@
     "import sys\n",
     "sys.path.append(\"../../\")\n",
     "\n",
-    "import itertools\n",
     "import logging\n",
-    "import os\n",
     "import time\n",
     "\n",
     "import numpy as np\n",
@@ -203,12 +201,11 @@
    ],
    "source": [
     "data = movielens.load_pandas_df(\n",
-    "    size=MOVIELENS_DATA_SIZE,\n",
-    "    header=['UserId','MovieId','Rating','Timestamp']\n",
+    "    size=MOVIELENS_DATA_SIZE\n",
     ")\n",
     "\n",
     "# Convert the float precision to 32-bit in order to reduce memory consumption \n",
-    "data.loc[:, 'Rating'] = data['Rating'].astype(np.float32)\n",
+    "data['rating'] = data['rating'].astype(np.float32)\n",
     "\n",
     "data.head()"
    ]
@@ -253,13 +250,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "header = {\n",
-    "    \"col_user\": \"UserId\",\n",
-    "    \"col_item\": \"MovieId\",\n",
-    "    \"col_rating\": \"Rating\",\n",
-    "    \"col_timestamp\": \"Timestamp\",\n",
-    "}\n",
-    "\n",
     "logging.basicConfig(level=logging.DEBUG, \n",
     "                    format='%(asctime)s %(levelname)-8s %(message)s')\n",
     "\n",
@@ -267,8 +257,7 @@
     "    similarity_type=\"jaccard\", \n",
     "    time_decay_coefficient=30, \n",
     "    time_now=None, \n",
-    "    timedecay_formula=True, \n",
-    "    **header\n",
+    "    timedecay_formula=True\n",
     ")"
    ]
   },
@@ -284,7 +273,7 @@
     "\n",
     "Recommendations are achieved by multiplying the affinity matrix $A$ and the similarity matrix $S$. The result is a ***recommendation score matrix*** $R$. We compute the ***top-k*** results for each user in the `recommend_k_items` function seen below.\n",
     "\n",
-    "A full walkthrough of the SAR algorithm can be found [here](../02_model/sar_deep_dive.ipynb)."
+    "A full walkthrough of the SAR algorithm can be found [here](../02_modeling/sar_educational_walkthrough.ipynb)."
    ]
   },
   {
@@ -351,11 +340,7 @@
     "top_k = model.recommend_k_items(test, remove_seen=True)\n",
     "\n",
     "test_time = time.time() - start_time\n",
-    "print(\"Took {} seconds for prediction.\".format(test_time))\n",
-    "\n",
-    "# TODO: remove this call when the model returns same type as input\n",
-    "top_k['UserId'] = pd.to_numeric(top_k['UserId'])\n",
-    "top_k['MovieId'] = pd.to_numeric(top_k['MovieId'])"
+    "print(\"Took {} seconds for prediction.\".format(test_time))"
    ]
   },
   {
@@ -458,9 +443,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eval_map = map_at_k(test, top_k, col_user=\"UserId\", col_item=\"MovieId\", \n",
-    "                    col_rating=\"Rating\", col_prediction=\"prediction\", \n",
-    "                    relevancy_method=\"top_k\", k=TOP_K)"
+    "eval_map = map_at_k(test, top_k, k=TOP_K)"
    ]
   },
   {
@@ -469,9 +452,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eval_ndcg = ndcg_at_k(test, top_k, col_user=\"UserId\", col_item=\"MovieId\", \n",
-    "                      col_rating=\"Rating\", col_prediction=\"prediction\", \n",
-    "                      relevancy_method=\"top_k\", k=TOP_K)"
+    "eval_ndcg = ndcg_at_k(test, top_k, k=TOP_K)"
    ]
   },
   {
@@ -480,9 +461,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eval_precision = precision_at_k(test, top_k, col_user=\"UserId\", col_item=\"MovieId\", \n",
-    "                                col_rating=\"Rating\", col_prediction=\"prediction\", \n",
-    "                                relevancy_method=\"top_k\", k=TOP_K)"
+    "eval_precision = precision_at_k(test, top_k, k=TOP_K)"
    ]
   },
   {
@@ -491,9 +470,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eval_recall = recall_at_k(test, top_k, col_user=\"UserId\", col_item=\"MovieId\", \n",
-    "                          col_rating=\"Rating\", col_prediction=\"prediction\", \n",
-    "                          relevancy_method=\"top_k\", k=TOP_K)"
+    "eval_recall = recall_at_k(test, top_k, k=TOP_K)"
    ]
   },
   {
@@ -587,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/02_model/sar_deep_dive.ipynb
+++ b/notebooks/02_model/sar_deep_dive.ipynb
@@ -70,9 +70,9 @@
     "\n",
     "Formalizing these factors produces us an expression for user-item affinity:\n",
     "\n",
-    "$$a_{ij}=\\sum_k w_k e^{[-\\text{log}(2)\\frac{t_0-t_k}{T}]} $$\n",
+    "$$a_{ij}=\\sum_k w_k \\left(\\frac{1}{2}\\right)^{\\frac{t_0-t_k}{T}} $$\n",
     "\n",
-    "where the affinity $a_{ij}$ for user $i$ and item $j$ is the weighted sum of all $k$ events involving user $i$ and item $j$. $w_k$ represents the weight of a particular event, and the exponential term reflects the temporally-discounted event. The $\\text{log}(2)$ scaling factor causes the parameter $T$ to serve as a half-life: events $T$ units before $t_0$ will be given half the weight as those taking place at $t_0$.\n",
+    "where the affinity $a_{ij}$ for user $i$ and item $j$ is the weighted sum of all $k$ events involving user $i$ and item $j$. $w_k$ represents the weight of a particular event, and the power of 2 term reflects the temporally-discounted event. The $(\\frac{1}{2})^n$ scaling factor causes the parameter $T$ to serve as a half-life: events $T$ units before $t_0$ will be given half the weight as those taking place at $t_0$.\n",
     "\n",
     "Repeating this computation for all $n$ users and $m$ items results in an $n\\times m$ matrix $A$. Simplifications of the above expression can be obtained by setting all the weights equal to 1 (effectively ignoring event types), or by setting the half-life parameter $T$ to infinity (ignoring transaction times).\n",
     "\n",
@@ -326,7 +326,6 @@
     "                    format='%(asctime)s %(levelname)-8s %(message)s')\n",
     "\n",
     "model = SARSingleNode(\n",
-    "    remove_seen=True, \n",
     "    similarity_type=\"jaccard\", \n",
     "    time_decay_coefficient=30, \n",
     "    time_now=None, \n",
@@ -377,7 +376,7 @@
     }
    ],
    "source": [
-    "top_k = model.recommend_k_items(test)"
+    "top_k = model.recommend_k_items(test, remove_seen=True)"
    ]
   },
   {
@@ -476,7 +475,7 @@
       ]
      },
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/notebooks/02_model/sar_deep_dive.ipynb
+++ b/notebooks/02_model/sar_deep_dive.ipynb
@@ -112,8 +112,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "System version: 3.6.7 | packaged by conda-forge | (default, Nov 21 2018, 03:09:43) \n",
-      "[GCC 7.3.0]\n",
+      "System version: 3.6.8 |Anaconda, Inc.| (default, Feb 11 2019, 15:03:47) [MSC v.1915 64 bit (AMD64)]\n",
       "Pandas version: 0.24.1\n"
      ]
     }
@@ -201,6 +200,7 @@
        "      <th>MovieId</th>\n",
        "      <th>Rating</th>\n",
        "      <th>Timestamp</th>\n",
+       "      <th>Title</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -210,46 +210,51 @@
        "      <td>242</td>\n",
        "      <td>3.0</td>\n",
        "      <td>881250949</td>\n",
+       "      <td>Kolya (1996)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>186</td>\n",
-       "      <td>302</td>\n",
+       "      <td>63</td>\n",
+       "      <td>242</td>\n",
        "      <td>3.0</td>\n",
-       "      <td>891717742</td>\n",
+       "      <td>875747190</td>\n",
+       "      <td>Kolya (1996)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>22</td>\n",
-       "      <td>377</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>878887116</td>\n",
+       "      <td>226</td>\n",
+       "      <td>242</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>883888671</td>\n",
+       "      <td>Kolya (1996)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>244</td>\n",
-       "      <td>51</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>880606923</td>\n",
+       "      <td>154</td>\n",
+       "      <td>242</td>\n",
+       "      <td>3.0</td>\n",
+       "      <td>879138235</td>\n",
+       "      <td>Kolya (1996)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>166</td>\n",
-       "      <td>346</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>886397596</td>\n",
+       "      <td>306</td>\n",
+       "      <td>242</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>876503793</td>\n",
+       "      <td>Kolya (1996)</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   UserId  MovieId  Rating  Timestamp\n",
-       "0     196      242     3.0  881250949\n",
-       "1     186      302     3.0  891717742\n",
-       "2      22      377     1.0  878887116\n",
-       "3     244       51     2.0  880606923\n",
-       "4     166      346     1.0  886397596"
+       "   UserId  MovieId  Rating  Timestamp         Title\n",
+       "0     196      242     3.0  881250949  Kolya (1996)\n",
+       "1      63      242     3.0  875747190  Kolya (1996)\n",
+       "2     226      242     5.0  883888671  Kolya (1996)\n",
+       "3     154      242     3.0  879138235  Kolya (1996)\n",
+       "4     306      242     5.0  876503793  Kolya (1996)"
       ]
      },
      "execution_count": 3,
@@ -260,7 +265,8 @@
    "source": [
     "data = movielens.load_pandas_df(\n",
     "    size=MOVIELENS_DATA_SIZE,\n",
-    "    header=['UserId','MovieId','Rating','Timestamp']\n",
+    "    header=['UserId', 'MovieId', 'Rating', 'Timestamp'],\n",
+    "    title_col='Title'\n",
     ")\n",
     "\n",
     "# Convert the float precision to 32-bit in order to reduce memory consumption \n",
@@ -294,11 +300,12 @@
    "outputs": [],
    "source": [
     "header = {\n",
-    "        \"col_user\": \"UserId\",\n",
-    "        \"col_item\": \"MovieId\",\n",
-    "        \"col_rating\": \"Rating\",\n",
-    "        \"col_timestamp\": \"Timestamp\",\n",
-    "    }"
+    "    \"col_user\": \"UserId\",\n",
+    "    \"col_item\": \"MovieId\",\n",
+    "    \"col_rating\": \"Rating\",\n",
+    "    \"col_timestamp\": \"Timestamp\",\n",
+    "    \"col_prediction\": \"Prediction\",\n",
+    "}"
    ]
   },
   {
@@ -343,16 +350,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-02-07 21:12:50,049 INFO     Collecting user affinity matrix\n",
-      "2019-02-07 21:12:50,055 INFO     Calculating time-decayed affinities\n",
-      "2019-02-07 21:12:50,135 INFO     Creating index columns\n",
-      "2019-02-07 21:12:50,164 INFO     Building user affinity sparse matrix\n",
-      "2019-02-07 21:12:50,174 INFO     Calculating item co-occurrence\n",
-      "2019-02-07 21:12:50,419 INFO     Calculating item similarity\n",
-      "2019-02-07 21:12:50,420 INFO     Calculating jaccard\n",
-      "2019-02-07 21:12:50,631 INFO     Calculating recommendation scores\n",
-      "2019-02-07 21:12:50,738 INFO     Removing seen items\n",
-      "2019-02-07 21:12:50,740 INFO     Done training\n"
+      "2019-03-05 14:47:47,579 INFO     Collecting user affinity matrix\n",
+      "2019-03-05 14:47:47,586 INFO     Calculating time-decayed affinities\n",
+      "2019-03-05 14:47:47,644 INFO     Creating index columns\n",
+      "2019-03-05 14:47:47,672 INFO     Building user affinity sparse matrix\n",
+      "2019-03-05 14:47:47,679 INFO     Calculating item co-occurrence\n",
+      "2019-03-05 14:47:47,880 INFO     Calculating item similarity\n",
+      "2019-03-05 14:47:47,882 INFO     Calculating jaccard\n",
+      "2019-03-05 14:47:48,092 INFO     Done training\n"
      ]
     }
    ],
@@ -371,23 +376,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-02-07 21:12:50,762 INFO     Getting top K\n"
+      "2019-03-05 14:47:48,104 INFO     Calculating recommendation scores\n",
+      "2019-03-05 14:47:48,245 INFO     Removing seen items\n",
+      "2019-03-05 14:47:48,258 INFO     Getting top K\n"
      ]
     }
    ],
    "source": [
     "top_k = model.recommend_k_items(test, remove_seen=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: remove this call when the model returns same type as input\n",
-    "top_k['UserId'] = pd.to_numeric(top_k['UserId'])\n",
-    "top_k['MovieId'] = pd.to_numeric(top_k['MovieId'])"
    ]
   },
   {
@@ -399,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
@@ -427,59 +423,108 @@
        "      <th></th>\n",
        "      <th>UserId</th>\n",
        "      <th>MovieId</th>\n",
-       "      <th>prediction</th>\n",
+       "      <th>Prediction</th>\n",
+       "      <th>Title</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>600</td>\n",
+       "      <th>4678</th>\n",
+       "      <td>943</td>\n",
+       "      <td>385</td>\n",
+       "      <td>22.063621</td>\n",
+       "      <td>True Lies (1994)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4674</th>\n",
+       "      <td>943</td>\n",
+       "      <td>79</td>\n",
+       "      <td>20.945250</td>\n",
+       "      <td>Fugitive, The (1993)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4675</th>\n",
+       "      <td>943</td>\n",
        "      <td>69</td>\n",
-       "      <td>12.984131</td>\n",
+       "      <td>20.665495</td>\n",
+       "      <td>Forrest Gump (1994)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>600</td>\n",
+       "      <th>4671</th>\n",
+       "      <td>943</td>\n",
+       "      <td>82</td>\n",
+       "      <td>20.615830</td>\n",
+       "      <td>Jurassic Park (1993)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4676</th>\n",
+       "      <td>943</td>\n",
+       "      <td>202</td>\n",
+       "      <td>20.333979</td>\n",
+       "      <td>Groundhog Day (1993)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4672</th>\n",
+       "      <td>943</td>\n",
+       "      <td>550</td>\n",
+       "      <td>20.223571</td>\n",
+       "      <td>Die Hard: With a Vengeance (1995)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4677</th>\n",
+       "      <td>943</td>\n",
+       "      <td>265</td>\n",
+       "      <td>20.060790</td>\n",
+       "      <td>Hunt for Red October, The (1990)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4679</th>\n",
+       "      <td>943</td>\n",
        "      <td>183</td>\n",
-       "      <td>13.106912</td>\n",
+       "      <td>19.947005</td>\n",
+       "      <td>Alien (1979)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>600</td>\n",
-       "      <td>89</td>\n",
-       "      <td>13.163791</td>\n",
+       "      <th>4673</th>\n",
+       "      <td>943</td>\n",
+       "      <td>403</td>\n",
+       "      <td>19.897583</td>\n",
+       "      <td>Batman (1989)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>600</td>\n",
-       "      <td>423</td>\n",
-       "      <td>12.991756</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>600</td>\n",
-       "      <td>144</td>\n",
-       "      <td>13.489795</td>\n",
+       "      <th>4670</th>\n",
+       "      <td>943</td>\n",
+       "      <td>168</td>\n",
+       "      <td>19.895860</td>\n",
+       "      <td>Monty Python and the Holy Grail (1974)</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   UserId  MovieId  prediction\n",
-       "0     600       69   12.984131\n",
-       "1     600      183   13.106912\n",
-       "2     600       89   13.163791\n",
-       "3     600      423   12.991756\n",
-       "4     600      144   13.489795"
+       "      UserId  MovieId  Prediction                                   Title\n",
+       "4678     943      385   22.063621                        True Lies (1994)\n",
+       "4674     943       79   20.945250                    Fugitive, The (1993)\n",
+       "4675     943       69   20.665495                     Forrest Gump (1994)\n",
+       "4671     943       82   20.615830                    Jurassic Park (1993)\n",
+       "4676     943      202   20.333979                    Groundhog Day (1993)\n",
+       "4672     943      550   20.223571       Die Hard: With a Vengeance (1995)\n",
+       "4677     943      265   20.060790        Hunt for Red October, The (1990)\n",
+       "4679     943      183   19.947005                            Alien (1979)\n",
+       "4673     943      403   19.897583                           Batman (1989)\n",
+       "4670     943      168   19.895860  Monty Python and the Holy Grail (1974)"
       ]
      },
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "display(top_k.head())"
+    "top_k_with_titles = (top_k.join(data[['MovieId', 'Title']].drop_duplicates().set_index('MovieId'), \n",
+    "                                on='MovieId', \n",
+    "                                how='inner').sort_values(by=['UserId', 'Prediction'], ascending=False))\n",
+    "display(top_k_with_titles.head(10))"
    ]
   },
   {
@@ -495,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +549,7 @@
     "kwargs = dict(col_user='UserId', \n",
     "              col_item='MovieId', \n",
     "              col_rating='Rating', \n",
-    "              col_prediction='prediction', \n",
+    "              col_prediction='Prediction', \n",
     "              relevancy_method='top_k', \n",
     "              k=TOP_K)\n",
     "\n",
@@ -516,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -525,10 +570,10 @@
      "text": [
       "Model:\t\t sar_ref\n",
       "Top K:\t\t 10\n",
-      "MAP:\t\t 0.105815\n",
-      "NDCG:\t\t 0.373197\n",
-      "Precision@K:\t 0.326617\n",
-      "Recall@K:\t 0.175957\n"
+      "MAP:\t\t 0.103501\n",
+      "NDCG:\t\t 0.368105\n",
+      "Precision@K:\t 0.317603\n",
+      "Recall@K:\t 0.169709\n"
      ]
     }
    ],
@@ -556,9 +601,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (reco)",
+   "display_name": "Python (reco_base)",
    "language": "python",
-   "name": "reco"
+   "name": "reco_base"
   },
   "language_info": {
    "codemirror_mode": {
@@ -570,7 +615,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/notebooks/02_model/sar_deep_dive.ipynb
+++ b/notebooks/02_model/sar_deep_dive.ipynb
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -257,7 +257,7 @@
        "4     306      242     5.0  876503793  Kolya (1996)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -270,7 +270,7 @@
     ")\n",
     "\n",
     "# Convert the float precision to 32-bit in order to reduce memory consumption \n",
-    "data.loc[:, 'Rating'] = data['Rating'].astype(np.float32)\n",
+    "data.loc[:, 'Rating'] = data['Rating'].astype(np.float64)\n",
     "\n",
     "data.head()"
    ]
@@ -286,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,21 +343,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-03-05 14:47:47,579 INFO     Collecting user affinity matrix\n",
-      "2019-03-05 14:47:47,586 INFO     Calculating time-decayed affinities\n",
-      "2019-03-05 14:47:47,644 INFO     Creating index columns\n",
-      "2019-03-05 14:47:47,672 INFO     Building user affinity sparse matrix\n",
-      "2019-03-05 14:47:47,679 INFO     Calculating item co-occurrence\n",
-      "2019-03-05 14:47:47,880 INFO     Calculating item similarity\n",
-      "2019-03-05 14:47:47,882 INFO     Calculating jaccard\n",
-      "2019-03-05 14:47:48,092 INFO     Done training\n"
+      "2019-03-07 12:21:26,960 INFO     Collecting user affinity matrix\n",
+      "2019-03-07 12:21:26,968 INFO     Calculating time-decayed affinities\n",
+      "2019-03-07 12:21:27,021 INFO     Creating index columns\n",
+      "2019-03-07 12:21:27,062 INFO     Building user affinity sparse matrix\n",
+      "2019-03-07 12:21:27,080 INFO     Calculating item co-occurrence\n",
+      "2019-03-07 12:21:27,308 INFO     Calculating item similarity\n",
+      "2019-03-07 12:21:27,310 INFO     Calculating jaccard\n",
+      "2019-03-07 12:21:27,499 INFO     Done training\n"
      ]
     }
    ],
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "metadata": {
     "scrolled": true
    },
@@ -376,9 +376,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-03-05 14:47:48,104 INFO     Calculating recommendation scores\n",
-      "2019-03-05 14:47:48,245 INFO     Removing seen items\n",
-      "2019-03-05 14:47:48,258 INFO     Getting top K\n"
+      "2019-03-07 12:21:29,667 INFO     Calculating recommendation scores\n",
+      "2019-03-07 12:21:29,820 INFO     Removing seen items\n",
+      "2019-03-07 12:21:29,833 INFO     Getting top K\n"
      ]
     }
    ],
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "metadata": {
     "scrolled": true
    },
@@ -488,7 +488,7 @@
        "      <th>4673</th>\n",
        "      <td>943</td>\n",
        "      <td>403</td>\n",
-       "      <td>19.897583</td>\n",
+       "      <td>19.897582</td>\n",
        "      <td>Batman (1989)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -512,7 +512,7 @@
        "4672     943      550   20.223571       Die Hard: With a Vengeance (1995)\n",
        "4677     943      265   20.060790        Hunt for Red October, The (1990)\n",
        "4679     943      183   19.947005                            Alien (1979)\n",
-       "4673     943      403   19.897583                           Batman (1989)\n",
+       "4673     943      403   19.897582                           Batman (1989)\n",
        "4670     943      168   19.895860  Monty Python and the Holy Grail (1974)"
       ]
      },
@@ -540,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {

--- a/reco_utils/common/python_utils.py
+++ b/reco_utils/common/python_utils.py
@@ -12,7 +12,7 @@ def exponential_decay(value, max_val, half_life):
         float: decay factor
     """
 
-    return np.minimum(1., np.exp(-np.log(2) * (max_val - value) / half_life))
+    return np.minimum(1., np.power(0.5, (max_val - value) / half_life))
 
 
 def jaccard(cooccurrence):

--- a/reco_utils/common/python_utils.py
+++ b/reco_utils/common/python_utils.py
@@ -12,7 +12,7 @@ def exponential_decay(value, max_val, half_life):
         float: decay factor
     """
 
-    return np.minimum(1., np.power(0.5, (max_val - value) / half_life))
+    return np.minimum(1.0, np.power(0.5, (max_val - value) / half_life))
 
 
 def jaccard(cooccurrence):
@@ -27,7 +27,7 @@ def jaccard(cooccurrence):
     diag_rows = np.expand_dims(diag, axis=0)
     diag_cols = np.expand_dims(diag, axis=1)
 
-    with np.errstate(invalid='ignore', divide='ignore'):
+    with np.errstate(invalid="ignore", divide="ignore"):
         result = cooccurrence / (diag_rows + diag_cols - cooccurrence)
 
     return np.array(result)
@@ -45,7 +45,7 @@ def lift(cooccurrence):
     diag_rows = np.expand_dims(diag, axis=0)
     diag_cols = np.expand_dims(diag, axis=1)
 
-    with np.errstate(invalid='ignore', divide='ignore'):
+    with np.errstate(invalid="ignore", divide="ignore"):
         result = cooccurrence / (diag_rows * diag_cols)
 
     return np.array(result)

--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -73,7 +73,7 @@ class SARSingleNode:
 
         # threshold - items below this number get set to zero in co-occurrence counts
         if self.threshold <= 0:
-            raise ValueError('Threshold cannot be < 1')
+            raise ValueError("Threshold cannot be < 1")
 
         # column for mapping user / item ids to internal indices
         self.col_item_id = sar.INDEXED_ITEMS
@@ -125,16 +125,10 @@ class SARSingleNode:
             np.array: Co-occurrence matrix
         """
 
-        user_item_hits = (
-            sparse.coo_matrix(
-                (
-                    np.repeat(1, df.shape[0]),
-                    (df[self.col_user_id], df[self.col_item_id]),
-                ),
-                shape=(n_users, n_items),
-            )
-            .tocsr()
-        )
+        user_item_hits = sparse.coo_matrix(
+            (np.repeat(1, df.shape[0]), (df[self.col_user_id], df[self.col_item_id])),
+            shape=(n_users, n_items),
+        ).tocsr()
 
         item_cooccurrence = user_item_hits.transpose().dot(user_item_hits)
         item_cooccurrence = item_cooccurrence.multiply(
@@ -233,10 +227,14 @@ class SARSingleNode:
             self.item_similarity = item_cooccurrence
         elif self.similarity_type == sar.SIM_JACCARD:
             logger.info("Calculating jaccard")
-            self.item_similarity = jaccard(item_cooccurrence).astype(df[self.col_rating].dtype)
+            self.item_similarity = jaccard(item_cooccurrence).astype(
+                df[self.col_rating].dtype
+            )
         elif self.similarity_type == sar.SIM_LIFT:
             logger.info("Calculating lift")
-            self.item_similarity = lift(item_cooccurrence).astype(df[self.col_rating].dtype)
+            self.item_similarity = lift(item_cooccurrence).astype(
+                df[self.col_rating].dtype
+            )
         else:
             raise ValueError(
                 "Unknown similarity type: {0}".format(self.similarity_type)
@@ -337,7 +335,9 @@ class SARSingleNode:
         item_ids = test[self.col_item].map(self.item2index).values
         nans = np.isnan(item_ids)
         if any(nans):
-            logger.warning("Items found in test not seen during training, new items will have score of 0")
+            logger.warning(
+                "Items found in test not seen during training, new items will have score of 0"
+            )
             test_scores = np.append(test_scores, np.zeros((self.n_users, 1)), axis=1)
             item_ids[nans] = self.n_items
             item_ids = item_ids.astype("int64")

--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -41,7 +41,6 @@ class SARSingleNode:
         """Initialize model parameters
 
         Args:
-            remove_seen (bool): whether to remove items observed in training when making recommendations
             col_user (str): user column name
             col_item (str): item column name
             col_rating (str): rating column name
@@ -49,7 +48,7 @@ class SARSingleNode:
             col_prediction (str): prediction column name
             similarity_type (str): [None, 'jaccard', 'lift'] option for computing item-item similarity
             time_decay_coefficient (float): number of days till ratings are decayed by 1/2
-            time_now (int): current time for time decay calculation
+            time_now (int | None): current time for time decay calculation
             timedecay_formula (bool): flag to apply time decay
             threshold (int): item-item co-occurrences below this threshold will be removed
         """
@@ -76,11 +75,11 @@ class SARSingleNode:
         if self.threshold <= 0:
             raise ValueError('Threshold cannot be < 1')
 
-        # Column for mapping user / item ids to internal indices
+        # column for mapping user / item ids to internal indices
         self.col_item_id = sar.INDEXED_ITEMS
         self.col_user_id = sar.INDEXED_USERS
 
-        # Obtain all the users and items from both training and test data
+        # obtain all the users and items from both training and test data
         self.n_users = None
         self.n_items = None
 
@@ -91,8 +90,8 @@ class SARSingleNode:
         # the opposite of the above map - map array index to actual string ID
         self.index2item = None
 
-        # affinity scores for the recommendation
-        self.scores = None
+        # track user-item pairs seen during training
+        self.seen_items = None
 
     def compute_affinity_matrix(self, df, n_users, n_items):
         """ Affinity matrix
@@ -135,7 +134,6 @@ class SARSingleNode:
                 shape=(n_users, n_items),
             )
             .tocsr()
-            .astype(df[self.col_rating].dtype)
         )
 
         item_cooccurrence = user_item_hits.transpose().dot(user_item_hits)
@@ -143,7 +141,7 @@ class SARSingleNode:
             item_cooccurrence >= self.threshold
         )
 
-        return item_cooccurrence
+        return item_cooccurrence.astype(df[self.col_rating].dtype)
 
     def set_index(self, df):
         """Generate continuous indices for users and items to reduce memory usage
@@ -152,13 +150,13 @@ class SARSingleNode:
             df (pd.DataFrame): dataframe with user and item ids
         """
 
-        # Generate a map of continuous index values to items
+        # generate a map of continuous index values to items
         self.index2item = dict(enumerate(df[self.col_item].unique()))
 
-        # Invert the mapping from above
+        # invert the mapping from above
         self.item2index = {v: k for k, v in self.index2item.items()}
 
-        # Create mapping of users to continuous indices
+        # create mapping of users to continuous indices
         self.user2index = {x[1]: x[0] for x in enumerate(df[self.col_user].unique())}
 
         # set values for the total count of users and items
@@ -172,7 +170,7 @@ class SARSingleNode:
             df (pd.DataFrame): User item rating dataframe
         """
 
-        # Generate continuous indices if this hasn't been done
+        # generate continuous indices if this hasn't been done
         if self.index2item is None:
             self.set_index(df)
 
@@ -180,7 +178,7 @@ class SARSingleNode:
         if not np.issubdtype(df[self.col_rating].dtype, np.floating):
             raise TypeError("Rating column data type must be floating point")
 
-        # Copy the DataFrame to avoid modification of the input
+        # copy the DataFrame to avoid modification of the input
         temp_df = df[[self.col_user, self.col_item, self.col_rating]].copy()
 
         if self.time_decay_flag:
@@ -208,28 +206,26 @@ class SARSingleNode:
             )
 
         logger.info("Creating index columns")
-        # Map users and items according to the two dicts. Add the two new columns to temp_df.
+        # map users and items according to the two dicts. Add the two new columns to temp_df.
         temp_df.loc[:, self.col_item_id] = temp_df[self.col_item].map(self.item2index)
         temp_df.loc[:, self.col_user_id] = temp_df[self.col_user].map(self.user2index)
 
-        seen_items = None
-        if self.remove_seen:
-            # retain seen items for removal at prediction time
-            seen_items = temp_df[[self.col_user_id, self.col_item_id]].values
+        # retain seen items for removal at prediction time
+        self.seen_items = temp_df[[self.col_user_id, self.col_item_id]].values
 
-        # Affinity matrix
+        # affinity matrix
         logger.info("Building user affinity sparse matrix")
         self.user_affinity = self.compute_affinity_matrix(
             temp_df, self.n_users, self.n_items
         )
 
-        # Calculate item co-occurrence
+        # calculate item co-occurrence
         logger.info("Calculating item co-occurrence")
         item_cooccurrence = self.compute_coocurrence_matrix(
             temp_df, self.n_users, self.n_items
         )
 
-        # Free up some space
+        # free up some space
         del temp_df
 
         logger.info("Calculating item similarity")
@@ -237,39 +233,28 @@ class SARSingleNode:
             self.item_similarity = item_cooccurrence
         elif self.similarity_type == sar.SIM_JACCARD:
             logger.info("Calculating jaccard")
-            self.item_similarity = jaccard(item_cooccurrence)
-            # Free up some space
-            del item_cooccurrence
+            self.item_similarity = jaccard(item_cooccurrence).astype(df[self.col_rating].dtype)
         elif self.similarity_type == sar.SIM_LIFT:
             logger.info("Calculating lift")
-            self.item_similarity = lift(item_cooccurrence)
-            # Free up some space
-            del item_cooccurrence
+            self.item_similarity = lift(item_cooccurrence).astype(df[self.col_rating].dtype)
         else:
             raise ValueError(
                 "Unknown similarity type: {0}".format(self.similarity_type)
             )
 
-        # Calculate raw scores with a matrix multiplication
-        logger.info("Calculating recommendation scores")
-        self.scores = self.user_affinity.dot(self.item_similarity)
-
-        # Remove items in the train set so recommended items are always novel
-        if self.remove_seen:
-            logger.info("Removing seen items")
-            self.scores[seen_items[:, 0], seen_items[:, 1]] = -np.inf
+        # free up some space
+        del item_cooccurrence
 
         logger.info("Done training")
 
-    def recommend_k_items(self, test, top_k=10, sort_top_k=False):
-        """Recommend top K items for all users which are in the test set
+    def score(self, test, remove_seen=False):
+        """Score all items for test users
 
         Args:
             test (pd.DataFrame): user to test
-            top_k (int): number of top items to recommend
-            sort_top_k (bool): flag to sort top k results
+            remove_seen (bool): flag to remove items seen in training from recommendation
         Returns:
-            pd.DataFrame: top k recommendation items for each user
+            np.ndarray
         """
 
         # get user / item indices from test set
@@ -277,28 +262,56 @@ class SARSingleNode:
         if any(np.isnan(user_ids)):
             raise ValueError("SAR cannot score users that are not in the training set")
 
-        # extract only the scores for the test users
-        test_scores = self.scores[user_ids, :]
+        # calculate raw scores with a matrix multiplication
+        logger.info("Calculating recommendation scores")
+        # TODO: only compute scores for users in test
+        test_scores = self.user_affinity.dot(self.item_similarity)
+
+        # remove items in the train set so recommended items are always novel
+        if remove_seen:
+            logger.info("Removing seen items")
+            test_scores[self.seen_items[:, 0], self.seen_items[:, 1]] = -np.inf
+
+        test_scores = test_scores[user_ids, :]
 
         # ensure we're working with a dense matrix
         if isinstance(test_scores, sparse.spmatrix):
             test_scores = test_scores.todense()
 
+        return test_scores
+
+    def recommend_k_items(self, test, top_k=10, sort_top_k=False, remove_seen=False):
+        """Recommend top K items for all users which are in the test set
+
+        Args:
+            test (pd.DataFrame): user to test
+            top_k (int): number of top items to recommend
+            sort_top_k (bool): flag to sort top k results
+            remove_seen (bool): flag to remove items seen in training from recommendation
+        Returns:
+            pd.DataFrame: top k recommendation items for each user
+        """
+
+        k = min(top_k, self.n_items)
+
+        test_scores = self.score(test, remove_seen=remove_seen)
+        test_user_idx = np.arange(test_scores.shape[0])[:, None]
+
         # get top K items and scores
         logger.info("Getting top K")
         # this determines the un-ordered top-k item indices for each user
-        top_items = np.argpartition(test_scores, -top_k, axis=1)[:, -top_k:]
-        top_scores = test_scores[np.arange(test_scores.shape[0])[:, None], top_items]
+        top_items = np.argpartition(test_scores, -k, axis=1)[:, -k:]
+        top_scores = test_scores[test_user_idx, top_items]
 
         if sort_top_k:
             sort_ind = np.argsort(-top_scores)
-            top_items = top_items[np.arange(top_items.shape[0])[:, None], sort_ind]
-            top_scores = top_scores[np.arange(top_scores.shape[0])[:, None], sort_ind]
+            top_items = top_items[test_user_idx, sort_ind]
+            top_scores = top_scores[test_user_idx, sort_ind]
 
         df = pd.DataFrame(
             {
                 self.col_user: np.repeat(
-                    test[self.col_user].drop_duplicates().values, top_k
+                    test[self.col_user].drop_duplicates().values, k
                 ),
                 self.col_item: [
                     self.index2item[item] for item in np.array(top_items).flatten()
@@ -307,16 +320,7 @@ class SARSingleNode:
             }
         )
 
-        # ensure datatypes are correct
-        df = df.astype(
-            dtype={
-                self.col_user: str,
-                self.col_item: str,
-                self.col_prediction: self.scores.dtype,
-            }
-        )
-
-        # drop seen items
+        # drop invalid items
         return df.replace(-np.inf, np.nan).dropna()
 
     def predict(self, test):
@@ -327,22 +331,13 @@ class SARSingleNode:
             pd.DataFrame: DataFrame contains the prediction results
         """
 
-        # get user / item indices from test set
-        user_ids = test[self.col_user].map(self.user2index).values
-        if any(np.isnan(user_ids)):
-            raise ValueError("SAR cannot score users that are not in the training set")
+        test_scores = self.score(test)
 
-        # extract only the scores for the test users
-        test_scores = self.scores[user_ids, :]
-
-        # convert and flatten scores into an array
-        if isinstance(test_scores, sparse.spmatrix):
-            test_scores = test_scores.todense()
-
+        # create mapping of new items to zeros
         item_ids = test[self.col_item].map(self.item2index).values
         nans = np.isnan(item_ids)
         if any(nans):
-            # predict 0 for items not seen during training
+            logger.warning("Items found in test not seen during training, new items will have score of 0")
             test_scores = np.append(test_scores, np.zeros((self.n_users, 1)), axis=1)
             item_ids[nans] = self.n_items
             item_ids = item_ids.astype("int64")
@@ -354,15 +349,6 @@ class SARSingleNode:
                 self.col_prediction: test_scores[
                     np.arange(test_scores.shape[0]), item_ids
                 ],
-            }
-        )
-
-        # ensure datatypes are correct
-        df = df.astype(
-            dtype={
-                self.col_user: str,
-                self.col_item: str,
-                self.col_prediction: self.scores.dtype,
             }
         )
 

--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -290,6 +290,8 @@ class SARSingleNode:
             pd.DataFrame: top k recommendation items for each user
         """
 
+        if self.n_items < top_k:
+            logger.warning('Number of items is less than top_k, limiting top_k to number of items')
         k = min(top_k, self.n_items)
 
         test_scores = self.score(test, remove_seen=remove_seen)

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -22,9 +22,7 @@ def _rearrange_to_test(array, row_ids, col_ids, row_map, col_map):
 
 
 def test_init(header):
-    model = SARSingleNode(
-        remove_seen=True, similarity_type="jaccard", **header
-    )
+    model = SARSingleNode(remove_seen=True, similarity_type="jaccard", **header)
 
     assert model.col_user == "UserId"
     assert model.col_item == "MovieId"
@@ -37,9 +35,7 @@ def test_init(header):
 )
 def test_fit(similarity_type, timedecay_formula, train_test_dummy_timestamp, header):
     model = SARSingleNode(
-        similarity_type=similarity_type,
-        timedecay_formula=timedecay_formula,
-        **header
+        similarity_type=similarity_type, timedecay_formula=timedecay_formula, **header
     )
     trainset, testset = train_test_dummy_timestamp
     model.fit(trainset)
@@ -52,9 +48,7 @@ def test_predict(
     similarity_type, timedecay_formula, train_test_dummy_timestamp, header
 ):
     model = SARSingleNode(
-        similarity_type=similarity_type,
-        timedecay_formula=timedecay_formula,
-        **header
+        similarity_type=similarity_type, timedecay_formula=timedecay_formula, **header
     )
     trainset, testset = train_test_dummy_timestamp
     model.fit(trainset)
@@ -111,11 +105,7 @@ def test_sar_item_similarity(
         )
     else:
         test_item_similarity = _rearrange_to_test(
-            model.item_similarity,
-            row_ids,
-            col_ids,
-            model.item2index,
-            model.item2index,
+            model.item_similarity, row_ids, col_ids, model.item2index, model.item2index
         )
         assert np.allclose(
             true_item_similarity.astype(test_item_similarity.dtype),
@@ -183,7 +173,7 @@ def test_recommend_k_items(
         ],
         top_k=10,
         sort_top_k=True,
-        remove_seen=True
+        remove_seen=True,
     )
     test_items = list(test_results[header["col_item"]])
     test_scores = np.array(test_results["prediction"])

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import pytest
-import itertools
 import numpy as np
 import pandas as pd
 from reco_utils.common.constants import PREDICTION_COL
@@ -38,7 +37,6 @@ def test_init(header):
 )
 def test_fit(similarity_type, timedecay_formula, train_test_dummy_timestamp, header):
     model = SARSingleNode(
-        remove_seen=True,
         similarity_type=similarity_type,
         timedecay_formula=timedecay_formula,
         **header
@@ -54,7 +52,6 @@ def test_predict(
     similarity_type, timedecay_formula, train_test_dummy_timestamp, header
 ):
     model = SARSingleNode(
-        remove_seen=True,
         similarity_type=similarity_type,
         timedecay_formula=timedecay_formula,
         **header
@@ -65,8 +62,8 @@ def test_predict(
 
     assert len(preds) == 2
     assert isinstance(preds, pd.DataFrame)
-    assert preds[header["col_user"]].dtype == object
-    assert preds[header["col_item"]].dtype == object
+    assert preds[header["col_user"]].dtype == trainset[header["col_user"]].dtype
+    assert preds[header["col_item"]].dtype == trainset[header["col_item"]].dtype
     assert preds[PREDICTION_COL].dtype == trainset[header["col_rating"]].dtype
 
 
@@ -86,7 +83,6 @@ def test_sar_item_similarity(
 ):
 
     model = SARSingleNode(
-        remove_seen=True,
         similarity_type=similarity_type,
         timedecay_formula=False,
         time_decay_coefficient=30,
@@ -131,7 +127,6 @@ def test_sar_item_similarity(
 def test_user_affinity(demo_usage_data, sar_settings, header):
     time_now = demo_usage_data[header["col_timestamp"]].max()
     model = SARSingleNode(
-        remove_seen=True,
         similarity_type="cooccurrence",
         timedecay_formula=True,
         time_decay_coefficient=30,
@@ -161,12 +156,11 @@ def test_user_affinity(demo_usage_data, sar_settings, header):
     "threshold,similarity_type,file",
     [(3, "cooccurrence", "count"), (3, "jaccard", "jac"), (3, "lift", "lift")],
 )
-def test_userpred(
+def test_recommend_k_items(
     threshold, similarity_type, file, header, sar_settings, demo_usage_data
 ):
     time_now = demo_usage_data[header["col_timestamp"]].max()
     model = SARSingleNode(
-        remove_seen=True,
         similarity_type=similarity_type,
         timedecay_formula=True,
         time_decay_coefficient=30,
@@ -188,7 +182,8 @@ def test_userpred(
             demo_usage_data[header["col_user"]] == sar_settings["TEST_USER_ID"]
         ],
         top_k=10,
-        sort_top_k=True
+        sort_top_k=True,
+        remove_seen=True
     )
     test_items = list(test_results[header["col_item"]])
     test_scores = np.array(test_results["prediction"])


### PR DESCRIPTION
### Description
Improvements to SAR Single Node implementation, this does not compute the full matrix multiplication during fit, just the user affinity and item similarity matrices (as well as keeping track of items seen during training).
The computation of the scores happens in a new score method, which is leveraged by predict and recommend_k_items. In the latter case the remove_seen flag can be used to remove items seen during training (this flag is removed from the constructor)

This tries harder to ensure the datatypes of the matrices match what is used as input (for both simplicity in evaluating / joining results afterwards and maintaining numerical precision for reduced memory use)

Additionally a small simplification of the exponential decay function (and corresponding formula in the deep dive notebook) were made.

The two notebooks were also cleaned up a bit to remove unnecessary arguments in favor of defaults, and to add the title column to help demonstrate results.

### Related Issues
#208


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [X] I have added tests.
- [X] I have updated the documentation accordingly.