### PR TITLE
updating notebook to explicitly use int64 datatype for prediction

### DIFF
--- a/notebooks/02_model/surprise_svd_deep_dive.ipynb
+++ b/notebooks/02_model/surprise_svd_deep_dive.ipynb
@@ -431,7 +431,7 @@
     "                                                     'est': 'prediction'})\n",
     "predictions = predictions.drop(['details', 'r_ui'], axis='columns')\n",
     "for col in ['userID', 'itemID']:\n",
-    "    predictions[col] = predictions[col].astype(int)\n",
+    "    predictions[col] = predictions[col].astype('int64')\n",
     "predictions.head()"
    ]
   },


### PR DESCRIPTION
### Description
explicitly convert userID and itemID columns to int64 (vs int) in surprise svd notebook

### Related Issues
#616 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [X] I have added tests.
- [X] I have updated the documentation accordingly.



