### PR TITLE
Movielens load movie's release year

### DIFF
--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -3,9 +3,14 @@
 
 import os
 import pytest
-import shutil
-from reco_utils.dataset import movielens
-from reco_utils.common.constants import DEFAULT_ITEM_COL
+from tempfile import TemporaryDirectory
+from reco_utils.dataset.movielens import (
+    load_pandas_df,
+    load_spark_df,
+    load_item_df,
+    download_movielens,
+    extract_movielens
+)
 
 try:
     from pyspark.sql.types import (
@@ -24,145 +29,154 @@ except ImportError:
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example, year_example",
+    "size, num_samples, num_movies, movie_example, title_example, genres_example, year_example",
     [
-        ("1m", 1000209, 3883, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
-        ("10m", 10000054, 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
-        ("20m", 20000263, 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("1m", 1000209, 3883, 1, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("10m", 10000054, 10681, 1, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("20m", 20000263, 27278, 1, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
     ],
 )
-def test_load_pandas_df(size, num_samples, num_movies, title_example, genres_example, year_example):
+def test_load_pandas_df(size, num_samples, num_movies, movie_example, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pd.DataFrame
     """
-    filename = "ml.zip"
-    local_cache_dir = os.path.join("data", size)
-    local_cache_path = os.path.join(local_cache_dir, filename)
+    # Test if correct data are loaded and local_cache_path works
+    with TemporaryDirectory() as tmp_dir:
+        # Test if can handle different size of header columns
+        header = ["a"]
+        df = load_pandas_df(size=size, local_cache_path=tmp_dir, header=header)
+        assert len(df) == num_samples
+        assert len(df.columns) == max(len(header), 2)  # Should load at least 2 columns, user and item
 
-    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path)
+        # Test title, genres, and released year load
+        header = ["a", "b", "c", "d", "e"]
+        with pytest.warns(Warning):
+            df = load_pandas_df(size=size, local_cache_path=tmp_dir,
+                                header=header, title_col="Title", genres_col="Genres", year_col="Year")
+            assert len(df) == num_samples
+            assert len(df.columns) == 7  # 4 header columns (user, item, rating, timestamp) and 3 feature columns
+            assert "e" not in df.columns  # only the first 4 header columns are used
+            # Get two records of the same items and check if the item-features are the same.
+            head = df.loc[df["b"] == movie_example][:2]
+            title = head["Title"].values
+            assert title[0] == title[1]
+            assert title[0] == title_example
+            genres = head["Genres"].values
+            assert genres[0] == genres[1]
+            assert genres[0] == genres_example
+            year = head["Year"].values
+            assert year[0] == year[1]
+            assert year[0] == year_example
+
+        # Test if raw-zip file, rating file, and item file are cached
+        assert len(os.listdir(tmp_dir)) == 3
+
+    # Test default arguments
+    df = load_pandas_df(size)
     assert len(df) == num_samples
     assert len(df.columns) == 4
-
-    # Test if can handle different size of header columns
-    header = ["a"]
-    df = movielens.load_pandas_df(size=size, header=header, local_cache_path=local_cache_path)
-    assert len(df.columns) == len(header)
-
-    # Test title, genres, and released year load
-    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path,
-                                  title_col="Title", genres_col="Genres", year_col="Year")
-    assert len(df.columns) == 7
-
-    # Get first two records of MovieID == 1, which is Toy Story
-    head = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]
-
-    title = head["Title"].values
-    assert title[0] == title[1]  # Check if two records are the same movie
-    assert title[0] == title_example  # Check if the record is Toy Story
-
-    genres = head["Genres"].values
-    assert genres[0] == genres[1]
-    assert genres[0] == genres_example
-
-    year = head["Year"].values
-    assert year[0] == year[1]
-    assert year[0] == year_example
-
-    shutil.rmtree(local_cache_dir, ignore_errors=True)
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "size, num_movies, title_example, genres_example, year_example",
+    "size, num_movies, movie_example, title_example, genres_example, year_example",
     [
-        ("1m", 3883, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
-        ("10m", 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
-        ("20m", 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("1m", 3883, 1, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("10m", 10681, 1, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("20m", 27278, 1, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
     ],
 )
-def test_load_item_df(size, num_movies, title_example, genres_example, year_example):
+def test_load_item_df(size, num_movies, movie_example, title_example, genres_example, year_example):
     """Test movielens item data load (not rating data)
     """
-    filename = "ml.zip"
-    local_cache_dir = os.path.join("data", size)
-    local_cache_path = os.path.join(local_cache_dir, filename)
-    df = movielens.load_item_df(size, local_cache_path=local_cache_path)
-    assert len(df) == num_movies
+    with TemporaryDirectory() as tmp_dir:
+        df = load_item_df(size, local_cache_path=tmp_dir, movie_col=None, title_col="title")
+        assert len(df) == num_movies
+        assert len(df.columns) == 1  # Only title column should be loaded
+        assert df["title"][0] == title_example
 
-    # Test title and genres
-    df = movielens.load_item_df(size, local_cache_path=local_cache_path, title_col="title", genres_col="genres")
-    assert len(df) == num_movies
-    assert df['title'][0] == title_example
-    assert df['genres'][0] == genres_example
+        # Test title and genres
+        df = load_item_df(size, local_cache_path=tmp_dir, movie_col="item", genres_col="genres")
+        assert len(df) == num_movies
+        assert len(df.columns) == 2  # movile_col and genres_col
+        assert df["item"][0] == movie_example
+        assert df["genres"][0] == genres_example
 
-    # Test released year
-    df = movielens.load_item_df(size, local_cache_path=local_cache_path, year_col="year")
-    assert len(df) == num_movies
-    assert df['year'][0] == year_example
-
-
-@pytest.mark.integration
-@pytest.mark.parametrize("size", ["1m", "10m", "20m"])
-def test_download_movielens(size):
-    """Test movielens data download
-    """
-    filename = "ml.zip"
-    movielens.download_movielens(size, filename)
-    assert os.path.exists(filename)
-    os.remove(filename)
+        # Test release year
+        df = load_item_df(size, local_cache_path=tmp_dir, year_col="year")
+        assert len(df) == num_movies
+        assert len(df.columns) == 2  # movile_col (default) and year_col
+        assert df["year"][0] == year_example
 
 
 @pytest.mark.integration
 @pytest.mark.spark
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example, year_example",
+    "size, num_samples, num_movies, movie_example, title_example, genres_example, year_example",
     [
-        ("1m", 1000209, 3883, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
-        ("10m", 10000054, 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
-        ("20m", 20000263, 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("1m", 1000209, 3883, 1, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("10m", 10000054, 10681, 1, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("20m", 20000263, 27278, 1, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
     ],
 )
-def test_load_spark_df(size, num_samples, num_movies, title_example, genres_example, year_example):
+def test_load_spark_df(size, num_samples, num_movies, movie_example, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pySpark.DataFrame
     """
     spark = start_or_get_spark("MovieLensLoaderTesting")
 
-    filename = "ml.zip"
-    local_cache_dir = os.path.join("data", size)
-    local_cache_path = os.path.join(local_cache_dir, filename)
+    # Test if correct data are loaded and local_cache_path works
+    with TemporaryDirectory() as tmp_dir:
+        # Test if can handle different size of header columns
+        header = ["1", "2"]
+        schema = StructType([StructField("u", IntegerType())])
+        with pytest.warns(Warning):
+            # Test if schema is used when both schema and header are provided
+            df = load_spark_df(spark, size=size, local_cache_path=tmp_dir, header=header, schema=schema)
+            assert df.count() == num_samples
+            assert len(df.columns) == len(schema)
 
-    # Check if the function load correct dataset
-    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path)
+        # Test title, genres, and released year load
+        header = ["a", "b", "c", "d", "e"]
+        with pytest.warns(Warning):
+            df = load_spark_df(spark, size=size, local_cache_path=tmp_dir,
+                               header=header, title_col="Title", genres_col="Genres", year_col="Year")
+            assert df.count() == num_samples
+            assert len(df.columns) == 7  # 4 header columns (user, item, rating, timestamp) and 3 feature columns
+            assert "e" not in df.columns  # only the first 4 header columns are used
+            # Get two records of the same items and check if the item-features are the same.
+            head = df.filter(col("b") == movie_example).limit(2)
+            title = head.select("Title").collect()
+            assert title[0][0] == title[1][0]
+            assert title[0][0] == title_example
+            genres = head.select("Genres").collect()
+            assert genres[0][0] == genres[1][0]
+            assert genres[0][0] == genres_example
+            year = head.select("Year").collect()
+            assert year[0][0] == year[1][0]
+            assert year[0][0] == year_example
+
+        # Test if raw-zip file, rating file, and item file are cached
+        assert len(os.listdir(tmp_dir)) == 3
+
+    # Test default arguments
+    df = load_spark_df(spark, size)
     assert df.count() == num_samples
     assert len(df.columns) == 4
 
-    # Test if can handle different size of header columns
-    header = ["1", "2"]
-    schema = StructType([StructField("u", IntegerType())])
-    with pytest.warns(Warning):
-        # Test if use schema when both schema and header are provided
-        df = movielens.load_spark_df(spark, size=size, header=header, schema=schema, local_cache_path=local_cache_path)
-        assert df.count() == num_samples
-        assert len(df.columns) == len(schema)
 
-    # Test title load
-    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path,
-                                 title_col="Title", genres_col="Genres", year_col="Year")
-    assert df.count() == num_samples
-    assert len(df.columns) == 7
+@pytest.mark.integration
+@pytest.mark.parametrize("size", ["1m", "10m", "20m"])
+def test_download_and_extract_movielens(size):
+    """Test movielens data download and extract
+    """
+    with TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "ml.zip")
+        download_movielens(size, dest_path=zip_path)
+        assert len(os.listdir(tmp_dir)) == 1
+        assert os.path.exists(zip_path)
 
-    # Get first two records of MovieID == 1, which is Toy Story
-    head = df.filter(col(DEFAULT_ITEM_COL) == 1).limit(2)
-
-    title = head.select("Title").collect()
-    assert title[0][0] == title[1][0]  # Check if two records are the same movie
-    assert title[0][0] == title_example  # Check if the record is Toy Story
-
-    genres = head.select("Genres").collect()
-    assert genres[0][0] == genres[1][0]
-    assert genres[0][0] == genres_example
-
-    year = head.select("Year").collect()
-    assert year[0][0] == year[1][0]
-    assert year[0][0] == year_example
-
-    shutil.rmtree(local_cache_dir, ignore_errors=True)
+        rating_path = os.path.join(tmp_dir, "rating.dat")
+        item_path = os.path.join(tmp_dir, "item.dat")
+        extract_movielens(size, rating_path=rating_path, item_path=item_path, zip_path=zip_path)
+        assert len(os.listdir(tmp_dir)) == 3
+        assert os.path.exists(rating_path)
+        assert os.path.exists(item_path)

--- a/tests/integration/test_movielens.py
+++ b/tests/integration/test_movielens.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import os
 import pytest
+import shutil
 from reco_utils.dataset import movielens
 from reco_utils.common.constants import DEFAULT_ITEM_COL
 
@@ -20,113 +22,147 @@ except ImportError:
     pass  # skip this import if we are in pure python environment
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example",
+    "size, num_samples, num_movies, title_example, genres_example, year_example",
     [
-        ("1m", 1000209, 3883, "Toy Story (1995)", "Animation|Children's|Comedy"),
-        ("10m", 10000054, 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy"),
-        ("20m", 20000263, 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy"),
+        ("1m", 1000209, 3883, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("10m", 10000054, 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("20m", 20000263, 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
     ],
 )
-def test_load_pandas_df(size, num_samples, num_movies, title_example, genres_example):
-    """Test MovieLens dataset load into pd.DataFrame"""
+def test_load_pandas_df(size, num_samples, num_movies, title_example, genres_example, year_example):
+    """Test MovieLens dataset load into pd.DataFrame
+    """
+    filename = "ml.zip"
+    local_cache_dir = os.path.join("data", size)
+    local_cache_path = os.path.join(local_cache_dir, filename)
 
-    df = movielens.load_pandas_df(size=size)
+    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path)
     assert len(df) == num_samples
     assert len(df.columns) == 4
 
     # Test if can handle different size of header columns
     header = ["a"]
-    df = movielens.load_pandas_df(header=header)
+    df = movielens.load_pandas_df(size=size, header=header, local_cache_path=local_cache_path)
     assert len(df.columns) == len(header)
 
-    header = ["a", "b", "c", "d", "e"]
-    with pytest.warns(Warning):
-        df = movielens.load_pandas_df(header=header)
-        assert len(df.columns) == 4
+    # Test title, genres, and released year load
+    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path,
+                                  title_col="Title", genres_col="Genres", year_col="Year")
+    assert len(df.columns) == 7
 
-    # Test title load
-    df = movielens.load_pandas_df(size=size, title_col="Title")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    title = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]["Title"].values
-    assert title[0] == title[1]
-    assert title[0] == title_example
+    # Get first two records of MovieID == 1, which is Toy Story
+    head = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]
 
-    # Test genres load
-    df = movielens.load_pandas_df(size=size, genres_col="Genres")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    genres = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]["Genres"].values
+    title = head["Title"].values
+    assert title[0] == title[1]  # Check if two records are the same movie
+    assert title[0] == title_example  # Check if the record is Toy Story
+
+    genres = head["Genres"].values
     assert genres[0] == genres[1]
     assert genres[0] == genres_example
 
-    # Test movie data load (not rating data)
-    df = movielens.load_pandas_df(size=size, header=None, title_col="Title", genres_col="Genres")
-    assert len(df) == num_movies
-    assert len(df.columns) == 3
+    year = head["Year"].values
+    assert year[0] == year[1]
+    assert year[0] == year_example
+
+    shutil.rmtree(local_cache_dir, ignore_errors=True)
 
 
-@pytest.mark.spark
+@pytest.mark.integration
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example",
+    "size, num_movies, title_example, genres_example, year_example",
     [
-        ("1m", 1000209, 3883, "Toy Story (1995)", "Animation|Children's|Comedy"),
-        ("10m", 10000054, 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy"),
-        ("20m", 20000263, 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy"),
+        ("1m", 3883, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("10m", 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("20m", 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
     ],
 )
-def test_load_spark_df(size, num_samples, num_movies, title_example, genres_example):
+def test_load_item_df(size, num_movies, title_example, genres_example, year_example):
+    """Test movielens item data load (not rating data)
+    """
+    filename = "ml.zip"
+    local_cache_dir = os.path.join("data", size)
+    local_cache_path = os.path.join(local_cache_dir, filename)
+    df = movielens.load_item_df(size, local_cache_path=local_cache_path)
+    assert len(df) == num_movies
+
+    # Test title and genres
+    df = movielens.load_item_df(size, local_cache_path=local_cache_path, title_col="title", genres_col="genres")
+    assert len(df) == num_movies
+    assert df['title'][0] == title_example
+    assert df['genres'][0] == genres_example
+
+    # Test released year
+    df = movielens.load_item_df(size, local_cache_path=local_cache_path, year_col="year")
+    assert len(df) == num_movies
+    assert df['year'][0] == year_example
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("size", ["1m", "10m", "20m"])
+def test_download_movielens(size):
+    """Test movielens data download
+    """
+    filename = "ml.zip"
+    movielens.download_movielens(size, filename)
+    assert os.path.exists(filename)
+    os.remove(filename)
+
+
+@pytest.mark.integration
+@pytest.mark.spark
+@pytest.mark.parametrize(
+    "size, num_samples, num_movies, title_example, genres_example, year_example",
+    [
+        ("1m", 1000209, 3883, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("10m", 10000054, 10681, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+        ("20m", 20000263, 27278, "Toy Story (1995)", "Adventure|Animation|Children|Comedy|Fantasy", "1995"),
+    ],
+)
+def test_load_spark_df(size, num_samples, num_movies, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pySpark.DataFrame
     """
     spark = start_or_get_spark("MovieLensLoaderTesting")
 
+    filename = "ml.zip"
+    local_cache_dir = os.path.join("data", size)
+    local_cache_path = os.path.join(local_cache_dir, filename)
+
     # Check if the function load correct dataset
-    df = movielens.load_spark_df(spark, size=size)
+    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path)
     assert df.count() == num_samples
     assert len(df.columns) == 4
 
     # Test if can handle different size of header columns
-    header = ["a"]
-    df = movielens.load_spark_df(spark, header=header)
-    assert len(df.columns) == len(header)
-
-    header = ["a", "b", "c", "d", "e"]
-    with pytest.warns(Warning):
-        df = movielens.load_spark_df(spark, header=header)
-        assert len(df.columns) == 4
-
-    # Test title load
-    df = movielens.load_spark_df(spark, size=size, title_col="Title")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    title = df.filter(col(DEFAULT_ITEM_COL) == 1).select("Title").limit(2).collect()
-    assert title[0][0] == title[1][0]
-    assert title[0][0] == title_example
-
-    # Test genres load
-    df = movielens.load_spark_df(spark, size=size, genres_col="Genres")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    genres = df.filter(col(DEFAULT_ITEM_COL) == 1).select("Genres").limit(2).collect()
-    assert genres[0][0] == genres[1][0]
-    assert genres[0][0] == genres_example
-
-    # Test movie data load (not rating data)
-    df = movielens.load_spark_df(spark, size=size, header=None, title_col="Title", genres_col="Genres")
-    assert df.count() == num_movies
-    assert len(df.columns) == 3
-
-    # Test if can handle wrong size argument
-    with pytest.raises(ValueError):
-        movielens.load_spark_df(spark, size='10k')
-    # Test if can handle wrong cache path argument
-    with pytest.raises(ValueError):
-        movielens.load_spark_df(spark, local_cache_path='.')
-
-    # Test if use schema when both schema and header are provided
     header = ["1", "2"]
     schema = StructType([StructField("u", IntegerType())])
     with pytest.warns(Warning):
-        df = movielens.load_spark_df(spark, header=header, schema=schema)
+        # Test if use schema when both schema and header are provided
+        df = movielens.load_spark_df(spark, size=size, header=header, schema=schema, local_cache_path=local_cache_path)
+        assert df.count() == num_samples
         assert len(df.columns) == len(schema)
+
+    # Test title load
+    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path,
+                                 title_col="Title", genres_col="Genres", year_col="Year")
+    assert df.count() == num_samples
+    assert len(df.columns) == 7
+
+    # Get first two records of MovieID == 1, which is Toy Story
+    head = df.filter(col(DEFAULT_ITEM_COL) == 1).limit(2)
+
+    title = head.select("Title").collect()
+    assert title[0][0] == title[1][0]  # Check if two records are the same movie
+    assert title[0][0] == title_example  # Check if the record is Toy Story
+
+    genres = head.select("Genres").collect()
+    assert genres[0][0] == genres[1][0]
+    assert genres[0][0] == genres_example
+
+    year = head.select("Year").collect()
+    assert year[0][0] == year[1][0]
+    assert year[0][0] == year_example
+
+    shutil.rmtree(local_cache_dir, ignore_errors=True)

--- a/tests/smoke/test_movielens.py
+++ b/tests/smoke/test_movielens.py
@@ -1,7 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import os
 import pytest
+import shutil
 from reco_utils.dataset import movielens
 from reco_utils.common.constants import DEFAULT_ITEM_COL
 
@@ -22,109 +24,151 @@ except ImportError:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example",
+    "size, num_samples, num_movies, title_example, genres_example, year_example",
     [
-        ("100k", 100000, 1682, "Toy Story (1995)", "Animation|Children's|Comedy"),
+        ("100k", 100000, 1682, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
     ],
 )
-def test_load_pandas_df(size, num_samples, num_movies, title_example, genres_example):
+def test_load_pandas_df(size, num_samples, num_movies, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pd.DataFrame
     """
-    df = movielens.load_pandas_df(size=size)
+    filename = "ml.zip"
+    local_cache_dir = os.path.join("data", size)
+    local_cache_path = os.path.join(local_cache_dir, filename)
+
+    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path)
     assert len(df) == num_samples
     assert len(df.columns) == 4
 
     # Test if can handle different size of header columns
     header = ["a"]
-    df = movielens.load_pandas_df(header=header)
+    df = movielens.load_pandas_df(size=size, header=header, local_cache_path=local_cache_path)
     assert len(df.columns) == len(header)
 
     header = ["a", "b", "c", "d", "e"]
     with pytest.warns(Warning):
-        df = movielens.load_pandas_df(header=header)
+        df = movielens.load_pandas_df(size=size, header=header, local_cache_path=local_cache_path)
         assert len(df.columns) == 4
 
-    # Test title load
-    df = movielens.load_pandas_df(size=size, title_col="Title")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    title = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]["Title"].values
-    assert title[0] == title[1]
-    assert title[0] == title_example
+    # Test title, genres, and released year load
+    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path,
+                                  title_col="Title", genres_col="Genres", year_col="Year")
+    assert len(df.columns) == 7
 
-    # Test genres load
-    df = movielens.load_pandas_df(size=size, genres_col="Genres")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    genres = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]["Genres"].values
+    # Get first two records of MovieID == 1, which is Toy Story
+    head = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]
+
+    title = head["Title"].values
+    assert title[0] == title[1]         # Check if two records are the same movie
+    assert title[0] == title_example    # Check if the record is Toy Story
+
+    genres = head["Genres"].values
     assert genres[0] == genres[1]
     assert genres[0] == genres_example
 
-    # Test movie data load (not rating data)
-    df = movielens.load_pandas_df(size=size, header=None, title_col="Title", genres_col="Genres")
-    assert len(df) == num_movies
-    assert len(df.columns) == 3
+    year = head["Year"].values
+    assert year[0] == year[1]
+    assert year[0] == year_example
 
-    
+    shutil.rmtree(local_cache_dir, ignore_errors=True)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "size, num_movies, title_example, genres_example, year_example",
+    [
+        ("100k", 1682, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+    ],
+)
+def test_load_item_df(size, num_movies, title_example, genres_example, year_example):
+    """Test movielens item data load (not rating data)
+    """
+    filename = "ml.zip"
+    local_cache_dir = os.path.join("data", size)
+    local_cache_path = os.path.join(local_cache_dir, filename)
+    df = movielens.load_item_df(size, local_cache_path=local_cache_path)
+    assert len(df) == num_movies
+
+    # Test title and genres
+    df = movielens.load_item_df(size, local_cache_path=local_cache_path, title_col="title", genres_col="genres")
+    assert len(df) == num_movies
+    assert df['title'][0] == title_example
+    assert df['genres'][0] == genres_example
+
+    # Test released year
+    df = movielens.load_item_df(size, local_cache_path=local_cache_path, year_col="year")
+    assert len(df) == num_movies
+    assert df['year'][0] == year_example
+
+    shutil.rmtree(local_cache_dir, ignore_errors=True)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("size", ["100k"])
+def test_download_movielens(size):
+    """Test movielens data download
+    """
+    filename = "ml.zip"
+    movielens.download_movielens(size, filename)
+    assert os.path.exists(filename)
+    os.remove(filename)
+
+
 @pytest.mark.smoke
 @pytest.mark.spark
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example",
+    "size, num_samples, num_movies, title_example, genres_example, year_example",
     [
-        ("100k", 100000, 1682, "Toy Story (1995)", "Animation|Children's|Comedy"),
+        ("100k", 100000, 1682, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
     ],
 )
-def test_load_spark_df(size, num_samples, num_movies, title_example, genres_example):
+def test_load_spark_df(size, num_samples, num_movies, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pySpark.DataFrame
     """
     spark = start_or_get_spark("MovieLensLoaderTesting")
 
+    filename = "ml.zip"
+    local_cache_dir = os.path.join("data", size)
+    local_cache_path = os.path.join(local_cache_dir, filename)
+
     # Check if the function load correct dataset
-    df = movielens.load_spark_df(spark, size=size)
+    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path)
     assert df.count() == num_samples
     assert len(df.columns) == 4
 
     # Test if can handle different size of header columns
-    header = ["a"]
-    df = movielens.load_spark_df(spark, header=header)
-    assert len(df.columns) == len(header)
-
-    header = ["a", "b", "c", "d", "e"]
-    with pytest.warns(Warning):
-        df = movielens.load_spark_df(spark, header=header)
-        assert len(df.columns) == 4
-
-    # Test title load
-    df = movielens.load_spark_df(spark, size=size, title_col="Title")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    title = df.filter(col(DEFAULT_ITEM_COL) == 1).select("Title").limit(2).collect()
-    assert title[0][0] == title[1][0]
-    assert title[0][0] == title_example
-
-    # Test genres load
-    df = movielens.load_spark_df(spark, size=size, genres_col="Genres")
-    assert len(df.columns) == 5
-    # Movie 1 is Toy Story
-    genres = df.filter(col(DEFAULT_ITEM_COL) == 1).select("Genres").limit(2).collect()
-    assert genres[0][0] == genres[1][0]
-    assert genres[0][0] == genres_example
-
-    # Test movie data load (not rating data)
-    df = movielens.load_spark_df(spark, size=size, header=None, title_col="Title", genres_col="Genres")
-    assert df.count() == num_movies
-    assert len(df.columns) == 3
-
-    # Test if can handle wrong size argument
-    with pytest.raises(ValueError):
-        movielens.load_spark_df(spark, size='10k')
-    # Test if can handle wrong cache path argument
-    with pytest.raises(ValueError):
-        movielens.load_spark_df(spark, local_cache_path='.')
-
-    # Test if use schema when both schema and header are provided
     header = ["1", "2"]
     schema = StructType([StructField("u", IntegerType())])
     with pytest.warns(Warning):
-        df = movielens.load_spark_df(spark, header=header, schema=schema)
+        # Test if use schema when both schema and header are provided
+        df = movielens.load_spark_df(spark, size=size, header=header, schema=schema, local_cache_path=local_cache_path)
+        assert df.count() == num_samples
         assert len(df.columns) == len(schema)
+    header = ["a", "b", "c", "d", "e"]
+    with pytest.warns(Warning):
+        df = movielens.load_spark_df(spark, size=size, header=header, local_cache_path=local_cache_path)
+        assert df.count() == num_samples
+        assert len(df.columns) == 4
+
+    # Test title load
+    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path,
+                                 title_col="Title", genres_col="Genres", year_col="Year")
+    assert df.count() == num_samples
+    assert len(df.columns) == 7
+
+    # Get first two records of MovieID == 1, which is Toy Story
+    head = df.filter(col(DEFAULT_ITEM_COL) == 1).limit(2)
+
+    title = head.select("Title").collect()
+    assert title[0][0] == title[1][0]       # Check if two records are the same movie
+    assert title[0][0] == title_example     # Check if the record is Toy Story
+
+    genres = head.select("Genres").collect()
+    assert genres[0][0] == genres[1][0]
+    assert genres[0][0] == genres_example
+
+    year = head.select("Year").collect()
+    assert year[0][0] == year[1][0]
+    assert year[0][0] == year_example
+
+    shutil.rmtree(local_cache_dir, ignore_errors=True)

--- a/tests/smoke/test_movielens.py
+++ b/tests/smoke/test_movielens.py
@@ -3,9 +3,14 @@
 
 import os
 import pytest
-import shutil
-from reco_utils.dataset import movielens
-from reco_utils.common.constants import DEFAULT_ITEM_COL
+from tempfile import TemporaryDirectory
+from reco_utils.dataset.movielens import (
+    load_pandas_df,
+    load_spark_df,
+    load_item_df,
+    download_movielens,
+    extract_movielens
+)
 
 try:
     from pyspark.sql.types import (
@@ -24,151 +29,148 @@ except ImportError:
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example, year_example",
+    "size, num_samples, num_movies, movie_example, title_example, genres_example, year_example",
     [
-        ("100k", 100000, 1682, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("100k", 100000, 1682, 1, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
     ],
 )
-def test_load_pandas_df(size, num_samples, num_movies, title_example, genres_example, year_example):
+def test_load_pandas_df(size, num_samples, num_movies, movie_example, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pd.DataFrame
     """
-    filename = "ml.zip"
-    local_cache_dir = os.path.join("data", size)
-    local_cache_path = os.path.join(local_cache_dir, filename)
+    # Test if correct data are loaded and local_cache_path works
+    with TemporaryDirectory() as tmp_dir:
+        # Test if can handle different size of header columns
+        header = ["a"]
+        df = load_pandas_df(size=size, local_cache_path=tmp_dir, header=header)
+        assert len(df) == num_samples
+        assert len(df.columns) == max(len(header), 2)  # Should load at least 2 columns, user and item
 
-    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path)
+        # Test title, genres, and released year load
+        header = ["a", "b", "c", "d", "e"]
+        with pytest.warns(Warning):
+            df = load_pandas_df(size=size, local_cache_path=tmp_dir,
+                                header=header, title_col="Title", genres_col="Genres", year_col="Year")
+            assert len(df) == num_samples
+            assert len(df.columns) == 7   # 4 header columns (user, item, rating, timestamp) and 3 feature columns
+            assert "e" not in df.columns  # only the first 4 header columns are used
+            # Get two records of the same items and check if the item-features are the same.
+            head = df.loc[df["b"] == movie_example][:2]
+            title = head["Title"].values
+            assert title[0] == title[1]
+            assert title[0] == title_example
+            genres = head["Genres"].values
+            assert genres[0] == genres[1]
+            assert genres[0] == genres_example
+            year = head["Year"].values
+            assert year[0] == year[1]
+            assert year[0] == year_example
+
+        # Test if raw-zip file, rating file, and item file are cached
+        assert len(os.listdir(tmp_dir)) == 3
+
+    # Test default arguments
+    df = load_pandas_df(size)
     assert len(df) == num_samples
     assert len(df.columns) == 4
-
-    # Test if can handle different size of header columns
-    header = ["a"]
-    df = movielens.load_pandas_df(size=size, header=header, local_cache_path=local_cache_path)
-    assert len(df.columns) == len(header)
-
-    header = ["a", "b", "c", "d", "e"]
-    with pytest.warns(Warning):
-        df = movielens.load_pandas_df(size=size, header=header, local_cache_path=local_cache_path)
-        assert len(df.columns) == 4
-
-    # Test title, genres, and released year load
-    df = movielens.load_pandas_df(size=size, local_cache_path=local_cache_path,
-                                  title_col="Title", genres_col="Genres", year_col="Year")
-    assert len(df.columns) == 7
-
-    # Get first two records of MovieID == 1, which is Toy Story
-    head = df.loc[df[DEFAULT_ITEM_COL] == 1][:2]
-
-    title = head["Title"].values
-    assert title[0] == title[1]         # Check if two records are the same movie
-    assert title[0] == title_example    # Check if the record is Toy Story
-
-    genres = head["Genres"].values
-    assert genres[0] == genres[1]
-    assert genres[0] == genres_example
-
-    year = head["Year"].values
-    assert year[0] == year[1]
-    assert year[0] == year_example
-
-    shutil.rmtree(local_cache_dir, ignore_errors=True)
 
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    "size, num_movies, title_example, genres_example, year_example",
+    "size, num_movies, movie_example, title_example, genres_example, year_example",
     [
-        ("100k", 1682, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("100k", 1682, 1, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
     ],
 )
-def test_load_item_df(size, num_movies, title_example, genres_example, year_example):
+def test_load_item_df(size, num_movies, movie_example, title_example, genres_example, year_example):
     """Test movielens item data load (not rating data)
     """
-    filename = "ml.zip"
-    local_cache_dir = os.path.join("data", size)
-    local_cache_path = os.path.join(local_cache_dir, filename)
-    df = movielens.load_item_df(size, local_cache_path=local_cache_path)
-    assert len(df) == num_movies
+    with TemporaryDirectory() as tmp_dir:
+        df = load_item_df(size, local_cache_path=tmp_dir, movie_col=None, title_col="title")
+        assert len(df) == num_movies
+        assert len(df.columns) == 1  # Only title column should be loaded
+        assert df["title"][0] == title_example
 
-    # Test title and genres
-    df = movielens.load_item_df(size, local_cache_path=local_cache_path, title_col="title", genres_col="genres")
-    assert len(df) == num_movies
-    assert df['title'][0] == title_example
-    assert df['genres'][0] == genres_example
+        # Test title and genres
+        df = load_item_df(size, local_cache_path=tmp_dir, movie_col="item", genres_col="genres")
+        assert len(df) == num_movies
+        assert len(df.columns) == 2  # movile_col and genres_col
+        assert df["item"][0] == movie_example
+        assert df["genres"][0] == genres_example
 
-    # Test released year
-    df = movielens.load_item_df(size, local_cache_path=local_cache_path, year_col="year")
-    assert len(df) == num_movies
-    assert df['year'][0] == year_example
-
-    shutil.rmtree(local_cache_dir, ignore_errors=True)
-
-
-@pytest.mark.smoke
-@pytest.mark.parametrize("size", ["100k"])
-def test_download_movielens(size):
-    """Test movielens data download
-    """
-    filename = "ml.zip"
-    movielens.download_movielens(size, filename)
-    assert os.path.exists(filename)
-    os.remove(filename)
+        # Test release year
+        df = load_item_df(size, local_cache_path=tmp_dir, year_col="year")
+        assert len(df) == num_movies
+        assert len(df.columns) == 2  # movile_col (default) and year_col
+        assert df["year"][0] == year_example
 
 
 @pytest.mark.smoke
 @pytest.mark.spark
 @pytest.mark.parametrize(
-    "size, num_samples, num_movies, title_example, genres_example, year_example",
+    "size, num_samples, num_movies, movie_example, title_example, genres_example, year_example",
     [
-        ("100k", 100000, 1682, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
+        ("100k", 100000, 1682, 1, "Toy Story (1995)", "Animation|Children's|Comedy", "1995"),
     ],
 )
-def test_load_spark_df(size, num_samples, num_movies, title_example, genres_example, year_example):
+def test_load_spark_df(size, num_samples, num_movies, movie_example, title_example, genres_example, year_example):
     """Test MovieLens dataset load into pySpark.DataFrame
     """
     spark = start_or_get_spark("MovieLensLoaderTesting")
 
-    filename = "ml.zip"
-    local_cache_dir = os.path.join("data", size)
-    local_cache_path = os.path.join(local_cache_dir, filename)
+    # Test if correct data are loaded and local_cache_path works
+    with TemporaryDirectory() as tmp_dir:
+        # Test if can handle different size of header columns
+        header = ["1", "2"]
+        schema = StructType([StructField("u", IntegerType())])
+        with pytest.warns(Warning):
+            # Test if schema is used when both schema and header are provided
+            df = load_spark_df(spark, size=size, local_cache_path=tmp_dir, header=header, schema=schema)
+            assert df.count() == num_samples
+            assert len(df.columns) == len(schema)
 
-    # Check if the function load correct dataset
-    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path)
+        # Test title, genres, and released year load
+        header = ["a", "b", "c", "d", "e"]
+        with pytest.warns(Warning):
+            df = load_spark_df(spark, size=size, local_cache_path=tmp_dir,
+                               header=header, title_col="Title", genres_col="Genres", year_col="Year")
+            assert df.count() == num_samples
+            assert len(df.columns) == 7   # 4 header columns (user, item, rating, timestamp) and 3 feature columns
+            assert "e" not in df.columns  # only the first 4 header columns are used
+            # Get two records of the same items and check if the item-features are the same.
+            head = df.filter(col("b") == movie_example).limit(2)
+            title = head.select("Title").collect()
+            assert title[0][0] == title[1][0]
+            assert title[0][0] == title_example
+            genres = head.select("Genres").collect()
+            assert genres[0][0] == genres[1][0]
+            assert genres[0][0] == genres_example
+            year = head.select("Year").collect()
+            assert year[0][0] == year[1][0]
+            assert year[0][0] == year_example
+
+        # Test if raw-zip file, rating file, and item file are cached
+        assert len(os.listdir(tmp_dir)) == 3
+
+    # Test default arguments
+    df = load_spark_df(spark, size)
     assert df.count() == num_samples
     assert len(df.columns) == 4
 
-    # Test if can handle different size of header columns
-    header = ["1", "2"]
-    schema = StructType([StructField("u", IntegerType())])
-    with pytest.warns(Warning):
-        # Test if use schema when both schema and header are provided
-        df = movielens.load_spark_df(spark, size=size, header=header, schema=schema, local_cache_path=local_cache_path)
-        assert df.count() == num_samples
-        assert len(df.columns) == len(schema)
-    header = ["a", "b", "c", "d", "e"]
-    with pytest.warns(Warning):
-        df = movielens.load_spark_df(spark, size=size, header=header, local_cache_path=local_cache_path)
-        assert df.count() == num_samples
-        assert len(df.columns) == 4
 
-    # Test title load
-    df = movielens.load_spark_df(spark, size=size, local_cache_path=local_cache_path,
-                                 title_col="Title", genres_col="Genres", year_col="Year")
-    assert df.count() == num_samples
-    assert len(df.columns) == 7
+@pytest.mark.smoke
+@pytest.mark.parametrize("size", ["100k"])
+def test_download_and_extract_movielens(size):
+    """Test movielens data download and extract
+    """
+    with TemporaryDirectory() as tmp_dir:
+        zip_path = os.path.join(tmp_dir, "ml.zip")
+        download_movielens(size, dest_path=zip_path)
+        assert len(os.listdir(tmp_dir)) == 1
+        assert os.path.exists(zip_path)
 
-    # Get first two records of MovieID == 1, which is Toy Story
-    head = df.filter(col(DEFAULT_ITEM_COL) == 1).limit(2)
-
-    title = head.select("Title").collect()
-    assert title[0][0] == title[1][0]       # Check if two records are the same movie
-    assert title[0][0] == title_example     # Check if the record is Toy Story
-
-    genres = head.select("Genres").collect()
-    assert genres[0][0] == genres[1][0]
-    assert genres[0][0] == genres_example
-
-    year = head.select("Year").collect()
-    assert year[0][0] == year[1][0]
-    assert year[0][0] == year_example
-
-    shutil.rmtree(local_cache_dir, ignore_errors=True)
+        rating_path = os.path.join(tmp_dir, "rating.dat")
+        item_path = os.path.join(tmp_dir, "item.dat")
+        extract_movielens(size, rating_path=rating_path, item_path=item_path, zip_path=zip_path)
+        assert len(os.listdir(tmp_dir)) == 3
+        assert os.path.exists(rating_path)
+        assert os.path.exists(item_path)

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import pytest
 
 from reco_utils.evaluation.parameter_sweep import generate_param_grid


### PR DESCRIPTION
### Description
Movie's release year can be used as an item feature along with rating timestamp.

Usage:
```
df = movielens.load_pandas_df(
    size="1m",
    header=("UserId", "MovieId", "Rating", "Timestamp"),
    title_col="Title",
    genres_col="Genres",
    year_col="Year"
)
```

Other changes include:
 - Refactor submodules, especially local cache path and cleanup
   (now download-and-extract only when ratings and movie data files
   do not exist in the local cache path)
 - Add download_movielens and load_item_df functions
 - Trim down redundant smoke and integration tests

### Related Issues
#645 #622 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [ ] I have updated the documentation accordingly.
