### PR TITLE
freeze papermill version to below 1.0

### DIFF
--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -67,7 +67,7 @@ PIP_BASE = {
     "idna": "idna==2.7",
     "memory-profiler": "memory-profiler>=0.54.0",
     "nvidia-ml-py3": "nvidia-ml-py3>=7.352.0",
-    "papermill": "papermill>=0.15.0",
+    "papermill": "papermill>=0.15.0,<1.0",
     "pydocumentdb": "pydocumentdb>=2.3.3",
 }
 


### PR DESCRIPTION
### Description
papermill is deprecating record() function. It will be removed in papermill 1.0. The function will be moved to scrapbook.
See announcement [here](https://nteract-scrapbook.readthedocs.io/en/latest/)

This is a one line change to freeze papermill version to below 1.0.

### Related Issues
[Issue 641 [BUG] Papermill Record is deprecated in Papermill 1.0 and has been replaced by scrapbook](https://github.com/Microsoft/Recommenders/issues/641)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.



