### PR TITLE
Gramhagen/add pip dependency

### DIFF
--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -43,6 +43,7 @@ CONDA_BASE = {
     "matplotlib": "matplotlib>=2.2.2",
     "numpy": "numpy>=1.13.3",
     "pandas": "pandas>=0.23.4",
+    "pip": "pip>=19.0.3",
     "pymongo": "pymongo>=3.6.1",
     "python": "python==3.6.8",
     "pytest": "pytest>=3.6.4",


### PR DESCRIPTION
### Description
adding pip as a conda dependency
currently the latest version of conda generates a warning and automatically injects pip into the dependency list. this will avoid that warning and insertion.

### Related Issues

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.