### PR TITLE
Fixing datatype checking issue and adding column checker method

### DIFF
--- a/reco_utils/dataset/pandas_df_utils.py
+++ b/reco_utils/dataset/pandas_df_utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import logging
+
 import pandas as pd
 import numpy as np
 
@@ -10,6 +12,9 @@ from reco_utils.common.constants import (
     DEFAULT_RATING_COL,
     DEFAULT_LABEL_COL
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def user_item_pairs(
@@ -315,3 +320,51 @@ def negative_feedback_sampler(
     )
 
     return df_sample
+
+
+def has_columns(df, columns):
+    """Check if DataFrame has necessary columns
+
+    Args:
+        df (pd.DataFrame): DataFrame
+        columns (list(str): columns to check for
+    Returns:
+        bool: True if DataFrame has specified columns
+    """
+
+    result = True
+    for column in columns:
+        if column not in df.columns:
+            logger.error('Missing column: {} in DataFrame'.format(column))
+            result = False
+
+    return result
+
+
+def has_same_base_dtype(df_1, df_2, columns=None):
+    """Check if specified columns have the same base dtypes across both DataFrames
+
+    Args:
+        df_1 (pd.DataFrame): first DataFrame
+        df_2 (pd.DataFrame): second DataFrame
+        columns (list(str)): columns to check, None checks all columns
+    Returns:
+        bool: True if DataFrames columns have the same base dtypes
+    """
+
+    if columns is None:
+        if any(set(df_1.columns).symmetric_difference(set(df_2.columns))):
+            logger.error('Cannot test all columns because they are not all shared across DataFrames')
+            return False
+        columns = df_1.columns
+
+    if not (has_columns(df=df_1, columns=columns) and has_columns(df=df_2, columns=columns)):
+        return False
+
+    result = True
+    for column in columns:
+        if df_1[column].dtype.type.__base__ != df_2[column].dtype.type.__base__:
+            logger.error('Columns {} do not have the same base datatype'.format(column))
+            result = False
+
+    return result

--- a/reco_utils/dataset/pandas_df_utils.py
+++ b/reco_utils/dataset/pandas_df_utils.py
@@ -10,7 +10,7 @@ from reco_utils.common.constants import (
     DEFAULT_USER_COL,
     DEFAULT_ITEM_COL,
     DEFAULT_RATING_COL,
-    DEFAULT_LABEL_COL
+    DEFAULT_LABEL_COL,
 )
 
 
@@ -129,9 +129,10 @@ class LibffmConverter(object):
         feature_count (int): count of feature in the libffm format data
         filepath (str or None): file path where the output is stored - it can be None or a string
     """
+
     def __init__(self, filepath=None):
         self.filepath = filepath
-    
+
     def fit(self, df, col_rating=DEFAULT_RATING_COL):
         """Fit the dataframe for libffm format. In there method does nothing but check the validity of 
         the input columns
@@ -145,11 +146,18 @@ class LibffmConverter(object):
         """
         # Check column types.
         types = df.dtypes
-        if not all([x == object or np.issubdtype(x, np.integer) or x == np.float for x in types]):
+        if not all(
+            [
+                x == object or np.issubdtype(x, np.integer) or x == np.float
+                for x in types
+            ]
+        ):
             raise TypeError("Input columns should be only object and/or numeric types.")
 
         if col_rating not in df.columns:
-            raise TypeError("Column of {} is not in input dataframe columns".format(col_rating))
+            raise TypeError(
+                "Column of {} is not in input dataframe columns".format(col_rating)
+            )
 
         self.col_rating = col_rating
         self.field_names = list(df.drop(col_rating, axis=1).columns)
@@ -167,10 +175,16 @@ class LibffmConverter(object):
             pd.DataFrame: output libffm format dataframe.
         """
         if not self.col_rating in df.columns:
-            raise ValueError("Input dataset does not contain the label column {} in the fitting dataset".format(self.col_rating))
+            raise ValueError(
+                "Input dataset does not contain the label column {} in the fitting dataset".format(
+                    self.col_rating
+                )
+            )
 
         if not all([x in df.columns for x in self.field_names]):
-            raise ValueError("Not all columns in the input dataset appear in the fitting dataset")
+            raise ValueError(
+                "Not all columns in the input dataset appear in the fitting dataset"
+            )
 
         # Encode field-feature.
         idx = 1
@@ -196,7 +210,9 @@ class LibffmConverter(object):
             return "{}:{}:{}".format(field_index, field_feature_index, feature)
 
         for col_index, col in enumerate(self.field_names):
-            df[col] = df[col].apply(lambda x: _convert(col, x, col_index+1, field_feature_dict))
+            df[col] = df[col].apply(
+                lambda x: _convert(col, x, col_index + 1, field_feature_dict)
+            )
 
         # Move rating column to the first.
         column_names = self.field_names[:]
@@ -204,7 +220,7 @@ class LibffmConverter(object):
         df = df[column_names]
 
         if self.filepath is not None:
-            np.savetxt(self.filepath, df.values, delimiter=' ', fmt='%s')
+            np.savetxt(self.filepath, df.values, delimiter=" ", fmt="%s")
 
         return df
 
@@ -227,18 +243,19 @@ class LibffmConverter(object):
             dict: parameters field count, feature count, and file path.
         """
         return {
-            'field count': self.field_count, 
-            'feature count': self.feature_count,
-            'file path': self.filepath
+            "field count": self.field_count,
+            "feature count": self.feature_count,
+            "file path": self.filepath,
         }
 
+
 def negative_feedback_sampler(
-    df, 
+    df,
     col_user=DEFAULT_USER_COL,
     col_item=DEFAULT_ITEM_COL,
     col_label=DEFAULT_LABEL_COL,
     ratio_neg_per_user=1,
-    seed=42
+    seed=42,
 ):
     """Utility function to sample negative feedback from user-item interaction dataset.
 
@@ -289,7 +306,11 @@ def negative_feedback_sampler(
     items = df[col_item].unique()
 
     # Create a dataframe for all user-item pairs
-    df_neg = user_item_pairs(pd.DataFrame(users, columns=[col_user]), pd.DataFrame(items, columns=[col_item]), user_item_filter_df = df)
+    df_neg = user_item_pairs(
+        pd.DataFrame(users, columns=[col_user]),
+        pd.DataFrame(items, columns=[col_item]),
+        user_item_filter_df=df,
+    )
     df_neg[col_label] = 0
 
     df_pos = df.copy()
@@ -300,19 +321,26 @@ def negative_feedback_sampler(
 
     # Sample negative feedback from the combined dataframe.
     df_sample = (
-        df_all
-        .groupby(col_user)
+        df_all.groupby(col_user)
         .apply(
             lambda x: pd.concat(
                 [
                     x[x[col_label] == 1],
-                    x[x[col_label] == 0].sample(min(
-                        max(round(len(x[x[col_label] == 1])*ratio_neg_per_user), 1),
-                        len(x[x[col_label] == 0])
-                    ), random_state=seed, replace=False) if len(x[x[col_label] == 0] > 0) else pd.DataFrame({}, columns=[col_user, col_item, col_label])
-                ], 
+                    x[x[col_label] == 0].sample(
+                        min(
+                            max(
+                                round(len(x[x[col_label] == 1]) * ratio_neg_per_user), 1
+                            ),
+                            len(x[x[col_label] == 0]),
+                        ),
+                        random_state=seed,
+                        replace=False,
+                    )
+                    if len(x[x[col_label] == 0] > 0)
+                    else pd.DataFrame({}, columns=[col_user, col_item, col_label]),
+                ],
                 ignore_index=True,
-                sort=True
+                sort=True,
             )
         )
         .reset_index(drop=True)
@@ -328,6 +356,7 @@ def has_columns(df, columns):
     Args:
         df (pd.DataFrame): DataFrame
         columns (list(str): columns to check for
+
     Returns:
         bool: True if DataFrame has specified columns
     """
@@ -335,7 +364,7 @@ def has_columns(df, columns):
     result = True
     for column in columns:
         if column not in df.columns:
-            logger.error('Missing column: {} in DataFrame'.format(column))
+            logger.error("Missing column: {} in DataFrame".format(column))
             result = False
 
     return result
@@ -348,23 +377,28 @@ def has_same_base_dtype(df_1, df_2, columns=None):
         df_1 (pd.DataFrame): first DataFrame
         df_2 (pd.DataFrame): second DataFrame
         columns (list(str)): columns to check, None checks all columns
+
     Returns:
         bool: True if DataFrames columns have the same base dtypes
     """
 
     if columns is None:
         if any(set(df_1.columns).symmetric_difference(set(df_2.columns))):
-            logger.error('Cannot test all columns because they are not all shared across DataFrames')
+            logger.error(
+                "Cannot test all columns because they are not all shared across DataFrames"
+            )
             return False
         columns = df_1.columns
 
-    if not (has_columns(df=df_1, columns=columns) and has_columns(df=df_2, columns=columns)):
+    if not (
+        has_columns(df=df_1, columns=columns) and has_columns(df=df_2, columns=columns)
+    ):
         return False
 
     result = True
     for column in columns:
         if df_1[column].dtype.type.__base__ != df_2[column].dtype.type.__base__:
-            logger.error('Columns {} do not have the same base datatype'.format(column))
+            logger.error("Columns {} do not have the same base datatype".format(column))
             result = False
 
     return result

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -21,25 +21,21 @@ from reco_utils.common.constants import (
     DEFAULT_K,
     DEFAULT_THRESHOLD,
 )
+from reco_utils.dataset.pandas_df_utils import has_columns, has_same_base_dtype
 
 
-def check_column_dtypes(f):
-    """Checks columns of dataframe inputs.
+def check_column_dtypes(func):
+    """Checks columns of DataFrame inputs
 
     This includes the checks on 
-        1. whether the input columns exist in the input dataframes.
-        2. whether the data types of col_user as well as col_item are matched in the two input dataframes.
-        
+        1. whether the input columns exist in the input DataFrames
+        2. whether the data types of col_user as well as col_item are matched in the two input DataFrames.
+
     Args:
-        rating_true (pd.DataFrame): True data.
-        rating_pred (pd.DataFrame): Predicted data.
-        col_user (str): column name for user.
-        col_item (str): column name for item.
-        col_rating (str): column name for rating.
-        col_prediction (str): column name for prediction.
+        func (function): function that will be wrapped
     """
 
-    @wraps(f)
+    @wraps(func)
     def check_column_dtypes_wrapper(
         rating_true,
         rating_pred,
@@ -50,32 +46,23 @@ def check_column_dtypes(f):
         *args,
         **kwargs
     ):
-        # check existence of input columns.
-        for col in [col_user, col_item, col_rating]:
-            if col not in rating_true.columns:
-                raise ValueError("schema of y_true not valid. missing {}".format(col))
+        """Check columns of DataFrame inputs
 
-        for col in [col_user, col_item, col_prediction]:
-            if col not in rating_pred.columns:
-                raise ValueError("schema of y_true not valid. missing {}".format(col))
+        Args:
+            rating_true (pd.DataFrame): True data
+            rating_pred (pd.DataFrame): Predicted data
+            col_user (str): column name for user
+            col_item (str): column name for item
+            col_rating (str): column name for rating
+            col_prediction (str): column name for prediction
+        """
 
-        # check matching of input column types. the evaluator requires two dataframes have the same
-        # data types of the input columns.
-        if rating_true[col_user].dtypes != rating_pred[col_user].dtypes:
-            raise TypeError(
-                "data types of column {} are different in true and prediction".format(
-                    col_user
-                )
-            )
+        assert has_columns(rating_true, [col_user, col_item, col_rating])
+        assert has_columns(rating_pred, [col_user, col_item, col_prediction])
 
-        if rating_true[col_item].dtypes != rating_pred[col_item].dtypes:
-            raise TypeError(
-                "data types of column {} are different in true and prediction".format(
-                    col_item
-                )
-            )
+        assert has_same_base_dtype(rating_true, rating_pred, columns=[col_user, col_item])
 
-        return f(
+        return func(
             rating_true=rating_true,
             rating_pred=rating_pred,
             col_user=col_user,
@@ -115,7 +102,7 @@ def merge_rating_true_pred(
     """
     suffixes = ["_true", "_pred"]
     # Apart from merging both dataframes, pd.merge will rename the columns with the suffixes only if the rating
-    # column name of rating_true is the same as the name rating column name in rating_pred
+    # column name of rating_true is the same as the name prediction column name in rating_pred
     rating_true_pred = pd.merge(
         rating_true, rating_pred, on=[col_user, col_item], suffixes=suffixes
     )
@@ -153,7 +140,6 @@ def rmse(
     y_true, y_pred = merge_rating_true_pred(
         rating_true, rating_pred, col_user, col_item, col_rating, col_prediction
     )
-
     return np.sqrt(mean_squared_error(y_true, y_pred))
 
 
@@ -303,7 +289,7 @@ def logloss(
         col_prediction (str): column name for prediction.
 
     Return:
-        float: log_loss_score (min=-\inf, max=\inf).
+        float: log_loss_score (min=-inf, max=inf).
     """
     y_true, y_pred = merge_rating_true_pred(
         rating_true, rating_pred, col_user, col_item, col_rating, col_prediction

--- a/reco_utils/evaluation/python_evaluation.py
+++ b/reco_utils/evaluation/python_evaluation.py
@@ -57,10 +57,14 @@ def check_column_dtypes(func):
             col_prediction (str): column name for prediction
         """
 
-        assert has_columns(rating_true, [col_user, col_item, col_rating])
-        assert has_columns(rating_pred, [col_user, col_item, col_prediction])
-
-        assert has_same_base_dtype(rating_true, rating_pred, columns=[col_user, col_item])
+        if not has_columns(rating_true, [col_user, col_item, col_rating]):
+            raise ValueError("Missing columns in true rating DataFrame")
+        if not has_columns(rating_pred, [col_user, col_item, col_prediction]):
+            raise ValueError("Missing columns in predicted rating DataFrame")
+        if not has_same_base_dtype(
+            rating_true, rating_pred, columns=[col_user, col_item]
+        ):
+            raise ValueError("Columns in provided DataFrames are not the same datatype")
 
         return func(
             rating_true=rating_true,
@@ -100,9 +104,9 @@ def merge_rating_true_pred(
         np.array: Array with the predicted ratings
 
     """
+
+    # pd.merge will apply suffixes to columns which have the same name across both dataframes
     suffixes = ["_true", "_pred"]
-    # Apart from merging both dataframes, pd.merge will rename the columns with the suffixes only if the rating
-    # column name of rating_true is the same as the name prediction column name in rating_pred
     rating_true_pred = pd.merge(
         rating_true, rating_pred, on=[col_user, col_item], suffixes=suffixes
     )
@@ -677,4 +681,3 @@ def get_top_k_items(
         .apply(lambda x: x.nlargest(k, col_rating))
         .reset_index(drop=True)
     )
-

--- a/tests/unit/test_pandas_df_utils.py
+++ b/tests/unit/test_pandas_df_utils.py
@@ -1,12 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import pytest
+import numpy as np
 import pandas as pd
+import pytest
+
 from reco_utils.dataset.pandas_df_utils import (
     user_item_pairs,
     filter_by,
-    LibffmConverter
+    LibffmConverter,
+    has_same_base_dtype,
+    has_columns,
 )
 
 
@@ -160,3 +164,41 @@ def test_csv_to_libffm():
         assert df_feature_new_libffm.iloc[-1, :].values.tolist() == [1, '1:4:1', '2:2:8', '3:3:6.0', '4:10:1']
 
 
+def test_has_columns():
+    df_1 = pd.DataFrame(dict(a=[1, 2, 3]))
+    df_2 = pd.DataFrame(dict(b=[7, 8, 9], a=[1, 2, 3]))
+
+    assert has_columns(df_1, ['a'])
+    assert has_columns(df_2, ['a'])
+    assert has_columns(df_2, ['a', 'b'])
+    assert not has_columns(df_2, ['a', 'b', 'c'])
+
+
+def test_has_same_base_dtype():
+    arr_int32 = np.array([1, 2, 3], dtype=np.int32)
+    arr_int64 = np.array([1, 2, 3], dtype=np.int64)
+    arr_float32 = np.array([1, 2, 3], dtype=np.float32)
+    arr_float64 = np.array([1, 2, 3], dtype=np.float64)
+    arr_str = ['a', 'b', 'c']
+
+    df_1 = pd.DataFrame(dict(a=arr_int32, b=arr_int64))
+    df_2 = pd.DataFrame(dict(a=arr_int64, b=arr_int32))
+    df_3 = pd.DataFrame(dict(a=arr_float32, b=arr_int32))
+    df_4 = pd.DataFrame(dict(a=arr_float64, b=arr_float64))
+    df_5 = pd.DataFrame(dict(a=arr_float64, b=arr_float64, c=arr_float64))
+    df_6 = pd.DataFrame(dict(a=arr_str))
+
+    # all columns match
+    assert has_same_base_dtype(df_1, df_2)
+    # specific column matches
+    assert has_same_base_dtype(df_3, df_4, columns=['a'])
+    # some column types do not match
+    assert not has_same_base_dtype(df_3, df_4)
+    # column types do not match
+    assert not has_same_base_dtype(df_1, df_3, columns=['a'])
+    # all columns are not shared
+    assert not has_same_base_dtype(df_4, df_5)
+    # column types do not match
+    assert not has_same_base_dtype(df_5, df_6, columns=['a'])
+    # assert string columns match
+    assert has_same_base_dtype(df_6, df_6)

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -130,10 +130,9 @@ def test_column_dtypes_match(python_data):
     rating_true_copy[DEFAULT_USER_COL] = rating_true_copy[DEFAULT_USER_COL].astype(str)
     rating_true_copy[DEFAULT_RATING_COL] = rating_true_copy[DEFAULT_RATING_COL].astype(str)
 
-    with pytest.raises(AssertionError) as e_info:
-        f = Mock()
-        f_d = check_column_dtypes(f)
-        f_d(
+    expected_error = "Columns in provided DataFrames are not the same datatype"
+    with pytest.raises(ValueError, match=expected_error):
+        check_column_dtypes(Mock())(
             rating_true_copy,
             rating_pred,
             col_user=DEFAULT_USER_COL,
@@ -141,9 +140,6 @@ def test_column_dtypes_match(python_data):
             col_rating=DEFAULT_RATING_COL,
             col_prediction=PREDICTION_COL
         )
-
-        # Error message is expected when there is mismatch.
-        assert str(e_info.value) == "Data types of column {} are different in true and prediction".format(DEFAULT_USER_COL)
 
 
 def test_merge_rating(python_data):
@@ -336,26 +332,26 @@ def test_python_logloss(python_data, target_metrics):
 def test_python_errors(python_data):
     rating_true, rating_pred, _ = python_data(binary_rating=False)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         rmse(rating_true, rating_true, col_user="not_user")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         mae(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_user="not_user")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         rsquared(rating_true, rating_pred, col_item="not_item")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         exp_var(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_item="not_item")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         precision_at_k(rating_true, rating_pred, col_rating="not_rating")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         recall_at_k(rating_true, rating_pred, col_prediction="not_prediction")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ndcg_at_k(rating_true, rating_true, col_user="not_user")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         map_at_k(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_user="not_user")

--- a/tests/unit/test_python_evaluation.py
+++ b/tests/unit/test_python_evaluation.py
@@ -130,7 +130,7 @@ def test_column_dtypes_match(python_data):
     rating_true_copy[DEFAULT_USER_COL] = rating_true_copy[DEFAULT_USER_COL].astype(str)
     rating_true_copy[DEFAULT_RATING_COL] = rating_true_copy[DEFAULT_RATING_COL].astype(str)
 
-    with pytest.raises(TypeError) as e_info:
+    with pytest.raises(AssertionError) as e_info:
         f = Mock()
         f_d = check_column_dtypes(f)
         f_d(
@@ -336,26 +336,26 @@ def test_python_logloss(python_data, target_metrics):
 def test_python_errors(python_data):
     rating_true, rating_pred, _ = python_data(binary_rating=False)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         rmse(rating_true, rating_true, col_user="not_user")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         mae(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_user="not_user")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         rsquared(rating_true, rating_pred, col_item="not_item")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         exp_var(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_item="not_item")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         precision_at_k(rating_true, rating_pred, col_rating="not_rating")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         recall_at_k(rating_true, rating_pred, col_prediction="not_prediction")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         ndcg_at_k(rating_true, rating_true, col_user="not_user")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         map_at_k(rating_pred, rating_pred, col_rating=PREDICTION_COL, col_user="not_user")


### PR DESCRIPTION
adding utils to check pandas columns and base datatypes, updating python evaluation to use those in check_column_dtypes decorator

two new methods in reco_utils.dataset.pandas_df_utils:
has_columns(df, columns) - ensures df has the list of columns specified
has_same_base_dtype(df1, df2, columns) - for each entry in columns checks that the base datatype is the same across df1 and df2

python_evaluation is updated to use these two functions

### Related Issues
#648 
#677 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.