### PR TITLE
Spark SETUP doc update

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -41,7 +41,7 @@ We install the dependencies with Conda. As a pre-requisite, we want to make sure
 
 ```{shell}
 conda update conda -n root
-conda update anaconda
+conda update anaconda        # use 'conda install anaconda' if the package is not installed
 ```
 
 We provide a script, [generate_conda_file.py](scripts/generate_conda_file.py), to generate a conda file, depending of the environment we want to use. This will create the environment using the Python version 3.6 with all the correct dependencies.

--- a/SETUP.md
+++ b/SETUP.md
@@ -32,7 +32,7 @@ Depending on the type of recommender system and the notebook that needs to be ru
 
 * Machine running Linux, Windows Subsystem for Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/about)) or macOS
 * Anaconda with Python version >= 3.6.
-  * This is pre-installed on Azure DSVM, for local setup [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
+  * This is pre-installed on Azure DSVM. For local setup [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
 * [Apache Spark](https://spark.apache.org/downloads.html) (this is only needed for the PySpark environment).
 
 ### Dependencies setup

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,9 +23,8 @@ This document describes how to setup all the dependencies to run the notebooks i
 
 Depending on the type of recommender system and the notebook that needs to be run, there are different computational requirements. Currently, this repository supports the following environments:
 
-* Python CPU
-* Python GPU
-* PySpark
+* Python CPU / GPU
+* PySpark CPU / GPU
 
 ## Setup guide for Local or DSVM
 
@@ -74,7 +73,7 @@ Assuming that you have a GPU machine, to install the Python GPU environment, whi
 </details>
 
 <details>
-<summary><strong><em>PySpark environment</em></strong></summary>
+<summary><strong><em>PySpark CPU environment</em></strong></summary>
 
 To install the PySpark environment, which by default installs the CPU environment:
 
@@ -89,7 +88,7 @@ Additionally, if you want to test a particular version of spark, you may pass th
 </details>
 
 <details>
-<summary><strong><em>All environments</em></strong></summary>
+<summary><strong><em>PySpark GPU environment</em></strong></summary>
 
 To install the PySpark GPU environment:
 
@@ -119,7 +118,7 @@ To install the PySpark GPU environment:
 > unset PYSPARK_PYTHON
 > unset PYSPARK_DRIVER_PYTHON
 > export SPARK_HOME=$SPARK_HOME_BACKUP
-> unset $SPARK_HOME_BACKUP
+> unset SPARK_HOME_BACKUP
 > ```
 
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -86,36 +86,42 @@ Additionally, if you want to test a particular version of spark, you may pass th
 
     python scripts/generate_conda_file.py --pyspark-version 2.4.0
 
-**NOTE** - for a PySpark environment, we need to set the environment variables `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` to point to the conda python executable.
-
-To set these variables every time the environment is activated, we can follow the steps of this [guide](https://conda.io/docs/user-guide/tasks/manage-environments.html#macos-and-linux). Assuming that we have installed the environment in `/anaconda/envs/reco_pyspark`, we create the file `/anaconda/envs/reco_pyspark/etc/conda/activate.d/env_vars.sh` and add:
-
-```bash
-#!/bin/sh
-export PYSPARK_PYTHON=/anaconda/envs/reco_pyspark/bin/python
-export PYSPARK_DRIVER_PYTHON=/anaconda/envs/reco_pyspark/bin/python
-unset SPARK_HOME
-```
-
-This will export the variables every time we do `conda activate reco_pyspark`. To unset these variables when we deactivate the environment, we create the file `/anaconda/envs/reco_pyspark/etc/conda/deactivate.d/env_vars.sh` and add:
-
-```bash
-#!/bin/sh
-unset PYSPARK_PYTHON
-unset PYSPARK_DRIVER_PYTHON
-```
 </details>
 
 <details>
 <summary><strong><em>All environments</em></strong></summary>
 
-To install all three environments:
+To install the PySpark GPU environment:
 
     cd Recommenders
     python scripts/generate_conda_file.py --gpu --pyspark
     conda env create -f reco_full.yaml
 
 </details>
+
+
+> **NOTE** - for PySpark environments (`reco_pyspark` and `reco_full`), we need to set the environment variables `PYSPARK_PYTHON` and `PYSPARK_DRIVER_PYTHON` to point to the conda python executable.
+> 
+> To set these variables every time the environment is activated, we can follow the steps of this [guide](https://conda.io/docs/user-guide/tasks/manage-environments.html#macos-and-linux). Assuming that we have installed the environment in `/anaconda/envs/reco_pyspark`, we create the file `/anaconda/envs/reco_pyspark/etc/conda/activate.d/env_vars.sh` and add:
+> 
+> ```bash
+> #!/bin/sh
+> export PYSPARK_PYTHON=/anaconda/envs/reco_pyspark/bin/python
+> export PYSPARK_DRIVER_PYTHON=/anaconda/envs/reco_pyspark/bin/python
+> export SPARK_HOME_BACKUP=$SPARK_HOME
+> unset SPARK_HOME
+> ```
+>
+> This will export the variables every time we do `conda activate reco_pyspark`. To unset these variables when we deactivate the environment, we create the file `/anaconda/envs/reco_pyspark/etc/conda/deactivate.d/env_vars.sh` and add:
+>
+> ```bash
+> #!/bin/sh
+> unset PYSPARK_PYTHON
+> unset PYSPARK_DRIVER_PYTHON
+> export SPARK_HOME=$SPARK_HOME_BACKUP
+> unset $SPARK_HOME_BACKUP
+> ```
+
 
 ### Register the conda environment as a kernel in Jupyter
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -73,7 +73,7 @@ Assuming that you have a GPU machine, to install the Python GPU environment, whi
 </details>
 
 <details>
-<summary><strong><em>PySpark CPU environment</em></strong></summary>
+<summary><strong><em>PySpark environment</em></strong></summary>
 
 To install the PySpark environment, which by default installs the CPU environment:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -32,7 +32,7 @@ Depending on the type of recommender system and the notebook that needs to be ru
 
 * Machine running Linux, Windows Subsystem for Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/about)) or macOS
 * Anaconda with Python version >= 3.6.
-  * This is pre-installed on Azure DSVM. For local setup [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
+  * This is pre-installed on Azure DSVM such that one can run the following steps directly. For local setup, [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
 * [Apache Spark](https://spark.apache.org/downloads.html) (this is only needed for the PySpark environment).
 
 ### Dependencies setup
@@ -88,7 +88,7 @@ Additionally, if you want to test a particular version of spark, you may pass th
 </details>
 
 <details>
-<summary><strong><em>PySpark GPU environment</em></strong></summary>
+<summary><strong><em>PySpark & GPU environment</em></strong></summary>
 
 To install the PySpark GPU environment:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -31,7 +31,7 @@ Currently, this repository supports **Python CPU**, **Python GPU** and **PySpark
 
 * A machine running Linux, Windows Subsystem for Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/about)) or macOS
 * Anaconda with Python version >= 3.6
-  * This is pre-installed on Azure DSVM such that one can run the following steps directly. For local setup, [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
+  * This is pre-installed on Azure DSVM such that one can run the following steps directly. To setup on your local machine, [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
 * [Apache Spark](https://spark.apache.org/downloads.html) (this is only needed for the PySpark environment).
 
 ### Dependencies setup
@@ -43,12 +43,9 @@ conda update conda -n root
 conda update anaconda        # use 'conda install anaconda' if the package is not installed
 ```
 
-We provide a script, [generate_conda_file.py](scripts/generate_conda_file.py), to generate a conda file depending on the environment you want to use.
-This will create the environment using the Python version 3.6 with all the correct dependencies.
+We provide a script, [generate_conda_file.py](scripts/generate_conda_file.py), to generate a conda-environment yaml file which you can use to create the target environment using the Python version 3.6 with all the correct dependencies.
 
-To install each environment, first generate a conda yaml file for the target environment, then create the environment by using the yaml file. 
-
-Assuming the repo is cloned as `Recommenders` in the local system, to install a base (Python CPU) environment:
+Assuming the repo is cloned as `Recommenders` in the local system, to install **a default (Python CPU) environment**:
 
     cd Recommenders
     python scripts/generate_conda_file.py

--- a/SETUP.md
+++ b/SETUP.md
@@ -21,17 +21,16 @@ This document describes how to setup all the dependencies to run the notebooks i
 
 ## Compute environments
 
-Depending on the type of recommender system and the notebook that needs to be run, there are different computational requirements. Currently, this repository supports the following environments:
+Depending on the type of recommender system and the notebook that needs to be run, there are different computational requirements.
+Currently, this repository supports **Python CPU**, **Python GPU** and **PySpark**.
 
-* Python CPU / GPU
-* PySpark CPU / GPU
 
 ## Setup guide for Local or DSVM
 
 ### Requirements
 
-* Machine running Linux, Windows Subsystem for Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/about)) or macOS
-* Anaconda with Python version >= 3.6.
+* A machine running Linux, Windows Subsystem for Linux ([WSL](https://docs.microsoft.com/en-us/windows/wsl/about)) or macOS
+* Anaconda with Python version >= 3.6
   * This is pre-installed on Azure DSVM such that one can run the following steps directly. For local setup, [Miniconda](https://docs.conda.io/en/latest/miniconda.html) is a quick way to get started.
 * [Apache Spark](https://spark.apache.org/downloads.html) (this is only needed for the PySpark environment).
 
@@ -44,27 +43,25 @@ conda update conda -n root
 conda update anaconda        # use 'conda install anaconda' if the package is not installed
 ```
 
-We provide a script, [generate_conda_file.py](scripts/generate_conda_file.py), to generate a conda file, depending of the environment we want to use. This will create the environment using the Python version 3.6 with all the correct dependencies.
+We provide a script, [generate_conda_file.py](scripts/generate_conda_file.py), to generate a conda file depending on the environment you want to use.
+This will create the environment using the Python version 3.6 with all the correct dependencies.
 
-To install each environment, first we need to generate a conda yaml file and then install the environment. We can specify the environment name with the input `-n`.
+To install each environment, first generate a conda yaml file for the target environment, then create the environment by using the yaml file. 
 
-Click on the following menus to see more details:
-
-<details>
-<summary><strong><em>Python CPU environment</em></strong></summary>
-
-Assuming the repo is cloned as `Recommenders` in the local system, to install the Python CPU environment:
+Assuming the repo is cloned as `Recommenders` in the local system, to install a base (Python CPU) environment:
 
     cd Recommenders
     python scripts/generate_conda_file.py
     conda env create -f reco_base.yaml 
 
-</details>
+You can specify the environment name as well with the flag `-n`.
+
+Click on the following menus to see how to install Python GPU and PySpark environments:
 
 <details>
 <summary><strong><em>Python GPU environment</em></strong></summary>
 
-Assuming that you have a GPU machine, to install the Python GPU environment, which by default installs the CPU environment:
+Assuming that you have a GPU machine, to install the Python GPU environment:
 
     cd Recommenders
     python scripts/generate_conda_file.py --gpu
@@ -75,7 +72,7 @@ Assuming that you have a GPU machine, to install the Python GPU environment, whi
 <details>
 <summary><strong><em>PySpark environment</em></strong></summary>
 
-To install the PySpark environment, which by default installs the CPU environment:
+To install the PySpark environment:
 
     cd Recommenders
     python scripts/generate_conda_file.py --pyspark
@@ -88,9 +85,10 @@ Additionally, if you want to test a particular version of spark, you may pass th
 </details>
 
 <details>
-<summary><strong><em>PySpark & GPU environment</em></strong></summary>
+<summary><strong><em>Full (PySpark & Python GPU) environment</em></strong></summary>
 
-To install the PySpark GPU environment:
+With this environment, you can run both PySpark and Python GPU notebooks in this repository.
+To install the environment:
 
     cd Recommenders
     python scripts/generate_conda_file.py --gpu --pyspark
@@ -128,6 +126,8 @@ We can register our created conda environment to appear as a kernel in the Jupyt
 
     conda activate my_env_name
     python -m ipykernel install --user --name my_env_name --display-name "Python (my_env_name)"
+    
+If you are using the DSVM, you can [connect to JupyterHub](https://docs.microsoft.com/en-us/azure/machine-learning/data-science-virtual-machine/dsvm-ubuntu-intro#jupyterhub-and-jupyterlab) by browsing to `https://your-vm-ip:8000`.
 
 ### Troubleshooting for the DSVM
 


### PR DESCRIPTION
### Description
* "Install All environments" actually installs one env, pyspark-gpu. Updated setup doc accordingly.
* Backup PYSPARK_HOME before unset and recover when deactivate the env, so that users don't need to restart the session.
* Spark env setup to be more visible: That section is related to both reco_pyspark and reco_full. So pulled out from spark-install section to end of the env installation.



