### PR TITLE
more readable collect_set in _get_top_k_items

### DIFF
--- a/reco_utils/evaluation/spark_evaluation.py
+++ b/reco_utils/evaluation/spark_evaluation.py
@@ -371,9 +371,8 @@ def _get_top_k_items(
             row_number().over(window_spec).alias("rank")
         )
         .where(col("rank") <= k)
-        .withColumn(col_prediction, F.collect_list(col_item).over(Window.partitionBy(col_user)))
-        .select(col_user, col_prediction)
-        .dropDuplicates([col_user, col_prediction])
+        .groupby(col_user)
+        .agg(F.collect_list('item').alias(col_prediction))
     )
 
     return items_for_user

--- a/reco_utils/evaluation/spark_evaluation.py
+++ b/reco_utils/evaluation/spark_evaluation.py
@@ -372,7 +372,7 @@ def _get_top_k_items(
         )
         .where(col("rank") <= k)
         .groupby(col_user)
-        .agg(F.collect_list('item').alias(col_prediction))
+        .agg(F.collect_list(col_item).alias(col_prediction))
     )
 
     return items_for_user


### PR DESCRIPTION
### Description
add more readable `collect_set` using `groupBy` instead of window functions

it gives same result.  
But if there are recommendations with equal ratings  
then recommendations can be different between runs, because there is no "right way to order equal numbers"

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



