### PR TITLE
Gramhagen/sar item sim

### DIFF
--- a/reco_utils/common/python_utils.py
+++ b/reco_utils/common/python_utils.py
@@ -1,4 +1,13 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import logging
+
 import numpy as np
+from scipy import sparse
+
+
+logger = logging.getLogger()
 
 
 def exponential_decay(value, max_val, half_life):
@@ -51,3 +60,38 @@ def lift(cooccurrence):
     return np.array(result)
 
 
+def get_top_k_scored_items(scores, top_k, sort_top_k=False):
+    """Extract top K items from a matrix of scores for each user-item pair, optionally sort results per user
+
+    Args:
+        scores (np.array): score matrix (users x items)
+        top_k (int): number of top items to recommend
+        sort_top_k (bool): flag to sort top k results
+
+    Returns:
+        np.array, np.array: indices into score matrix for each users top items, scores corresponding to top items
+    """
+
+    # ensure we're working with a dense ndarray
+    if isinstance(scores, sparse.spmatrix):
+        scores = scores.todense()
+
+    if scores.shape[1] < top_k:
+        logger.warning(
+            "Number of items is less than top_k, limiting top_k to number of items"
+        )
+    k = min(top_k, scores.shape[1])
+
+    test_user_idx = np.arange(scores.shape[0])[:, None]
+
+    # get top K items and scores
+    # this determines the un-ordered top-k item indices for each user
+    top_items = np.argpartition(scores, -k, axis=1)[:, -k:]
+    top_scores = scores[test_user_idx, top_items]
+
+    if sort_top_k:
+        sort_ind = np.argsort(-top_scores)
+        top_items = top_items[test_user_idx, sort_ind]
+        top_scores = top_scores[test_user_idx, sort_ind]
+
+    return np.array(top_items), np.array(top_scores)

--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -103,6 +103,7 @@ class SARSingleNode:
             df (pd.DataFrame): Indexed df of users and items.
             n_users (int): Number of users.
             n_items (int): Number of items.
+
         Returns:
             sparse.csr: Affinity matrix in Compressed Sparse Row (CSR) format.
         """
@@ -121,6 +122,7 @@ class SARSingleNode:
             df (pd.DataFrame): Indexed df of users and items.
             n_users (int): Number of users.
             n_items (int): Number of items.
+
         Returns:
             np.array: Co-occurrence matrix
         """
@@ -251,6 +253,7 @@ class SARSingleNode:
         Args:
             test (pd.DataFrame): user to test
             remove_seen (bool): flag to remove items seen in training from recommendation
+
         Returns:
             np.ndarray
         """
@@ -278,14 +281,81 @@ class SARSingleNode:
 
         return test_scores
 
+    def recommend_similar_items(self, items, top_k=10, sort_top_k=False):
+        """Recommend top K items similar to the provided seed items
+
+        Args:
+            items (pd.DataFrame): dataframe with item, user (optional), and rating (optional) columns
+            top_k (int): number of top items to recommend
+            sort_top_k (bool): flag to sort top k results
+
+        Returns:
+            pd.DataFrame: sorted top k recommendation items
+        """
+
+        # convert item ids to indices
+        item_ids = items[self.col_item].map(self.item2index)
+
+        # if no ratings were provided assume they are all 1
+        if self.col_rating in items.columns:
+            ratings = items[self.col_rating]
+        else:
+            ratings = pd.Series(np.ones_like(item_ids))
+
+        # create local map of user ids
+        if self.col_user in items.columns:
+            test_users = items[self.col_user]
+            user2index = {x[1]: x[0] for x in enumerate(items[self.col_user].unique())}
+            user_ids = test_users.map(user2index)
+        else:
+            # if no user column exists assume all entries are for a single user
+            test_users = pd.Series(np.zeros_like(item_ids))
+            user_ids = test_users
+        n_users = user_ids.drop_duplicates().shape[0]
+
+        # generate pseudo user affinity using seed items
+        pseudo_affinity = sparse.coo_matrix(
+            (ratings, (user_ids, item_ids)),
+            shape=(n_users, self.n_items),
+        ).tocsr()
+
+        # calculate raw scores with a matrix multiplication
+        test_scores = pseudo_affinity.dot(self.item_similarity)
+
+        # remove items in the seed set so recommended items are novel
+        test_scores[user_ids, item_ids] = -np.inf
+
+        # ensure we're working with a dense matrix
+        if isinstance(test_scores, sparse.spmatrix):
+            test_scores = test_scores.todense()
+
+        return self.get_top_k_items(users=test_users, scores=test_scores, top_k=top_k, sort_top_k=sort_top_k)
+
     def recommend_k_items(self, test, top_k=10, sort_top_k=False, remove_seen=False):
         """Recommend top K items for all users which are in the test set
 
         Args:
-            test (pd.DataFrame): user to test
+            test (pd.DataFrame): users to test
             top_k (int): number of top items to recommend
             sort_top_k (bool): flag to sort top k results
             remove_seen (bool): flag to remove items seen in training from recommendation
+
+        Returns:
+            pd.DataFrame: top k recommendation items for each user
+        """
+
+        test_scores = self.score(test, remove_seen=remove_seen)
+        return self.get_top_k_items(users=test[self.col_user], scores=test_scores, top_k=top_k, sort_top_k=sort_top_k)
+
+    def get_top_k_items(self, users, scores, top_k, sort_top_k=False):
+        """Extract top K items from score matrix, optionally sort results per user
+
+        Args:
+            users (pd.Series): test users
+            scores (np.array): score matrix
+            top_k (int): number of top items to recommend
+            sort_top_k (bool): flag to sort top k results
+
         Returns:
             pd.DataFrame: top k recommendation items for each user
         """
@@ -294,14 +364,13 @@ class SARSingleNode:
             logger.warning('Number of items is less than top_k, limiting top_k to number of items')
         k = min(top_k, self.n_items)
 
-        test_scores = self.score(test, remove_seen=remove_seen)
-        test_user_idx = np.arange(test_scores.shape[0])[:, None]
+        test_user_idx = np.arange(scores.shape[0])[:, None]
 
         # get top K items and scores
         logger.info("Getting top K")
         # this determines the un-ordered top-k item indices for each user
-        top_items = np.argpartition(test_scores, -k, axis=1)[:, -k:]
-        top_scores = test_scores[test_user_idx, top_items]
+        top_items = np.argpartition(scores, -k, axis=1)[:, -k:]
+        top_scores = scores[test_user_idx, top_items]
 
         if sort_top_k:
             sort_ind = np.argsort(-top_scores)
@@ -311,7 +380,7 @@ class SARSingleNode:
         df = pd.DataFrame(
             {
                 self.col_user: np.repeat(
-                    test[self.col_user].drop_duplicates().values, k
+                    users.drop_duplicates().values, k
                 ),
                 self.col_item: [
                     self.index2item[item] for item in np.array(top_items).flatten()
@@ -327,7 +396,8 @@ class SARSingleNode:
         """Output SAR scores for only the users-items pairs which are in the test set
         Args:
             test (pd.DataFrame): DataFrame that contains users and items to test
-        Return:
+
+        Returns:
             pd.DataFrame: DataFrame contains the prediction results
         """
 

--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -315,8 +315,7 @@ class SARSingleNode:
 
         # generate pseudo user affinity using seed items
         pseudo_affinity = sparse.coo_matrix(
-            (ratings, (user_ids, item_ids)),
-            shape=(n_users, self.n_items),
+            (ratings, (user_ids, item_ids)), shape=(n_users, self.n_items)
         ).tocsr()
 
         # calculate raw scores with a matrix multiplication
@@ -329,7 +328,9 @@ class SARSingleNode:
         if isinstance(test_scores, sparse.spmatrix):
             test_scores = test_scores.todense()
 
-        return self.get_top_k_items(users=test_users, scores=test_scores, top_k=top_k, sort_top_k=sort_top_k)
+        return self.get_top_k_items(
+            users=test_users, scores=test_scores, top_k=top_k, sort_top_k=sort_top_k
+        )
 
     def recommend_k_items(self, test, top_k=10, sort_top_k=False, remove_seen=False):
         """Recommend top K items for all users which are in the test set
@@ -345,7 +346,12 @@ class SARSingleNode:
         """
 
         test_scores = self.score(test, remove_seen=remove_seen)
-        return self.get_top_k_items(users=test[self.col_user], scores=test_scores, top_k=top_k, sort_top_k=sort_top_k)
+        return self.get_top_k_items(
+            users=test[self.col_user],
+            scores=test_scores,
+            top_k=top_k,
+            sort_top_k=sort_top_k,
+        )
 
     def get_top_k_items(self, users, scores, top_k, sort_top_k=False):
         """Extract top K items from score matrix, optionally sort results per user
@@ -361,7 +367,9 @@ class SARSingleNode:
         """
 
         if self.n_items < top_k:
-            logger.warning('Number of items is less than top_k, limiting top_k to number of items')
+            logger.warning(
+                "Number of items is less than top_k, limiting top_k to number of items"
+            )
         k = min(top_k, self.n_items)
 
         test_user_idx = np.arange(scores.shape[0])[:, None]
@@ -379,9 +387,7 @@ class SARSingleNode:
 
         df = pd.DataFrame(
             {
-                self.col_user: np.repeat(
-                    users.drop_duplicates().values, k
-                ),
+                self.col_user: np.repeat(users.drop_duplicates().values, k),
                 self.col_item: [
                     self.index2item[item] for item in np.array(top_items).flatten()
                 ],
@@ -419,7 +425,7 @@ class SARSingleNode:
             {
                 self.col_user: test[self.col_user].values,
                 self.col_item: test[self.col_item].values,
-                self.col_prediction: test_scores[user_ids, item_ids]
+                self.col_prediction: test_scores[user_ids, item_ids],
             }
         )
 

--- a/tests/unit/test_python_utils.py
+++ b/tests/unit/test_python_utils.py
@@ -10,7 +10,8 @@ import pytest
 from reco_utils.common.python_utils import (
     exponential_decay,
     jaccard,
-    lift
+    lift,
+    get_top_k_scored_items,
 )
 
 TOL = 0.0001
@@ -79,3 +80,11 @@ def test_exponential_decay():
     expected = np.array([0.25, 0.35355339, 0.5, 0.70710678, 1., 1.])
     actual = exponential_decay(value=values, max_val=5, half_life=2)
     assert np.allclose(actual, expected, atol=TOL)
+
+
+def test_get_top_k_scored_items():
+    scores = np.array([[1, 2, 3, 4, 5], [5, 4, 3, 2, 1], [1, 5, 3, 4, 2]])
+    top_items, top_scores = get_top_k_scored_items(scores=scores, top_k=3, sort_top_k=True)
+
+    assert np.array_equal(top_items, np.array([[4, 3, 2], [0, 1, 2], [1, 3, 2]]))
+    assert np.array_equal(top_scores, np.array([[5, 4, 3], [5, 4, 3], [5, 4, 3]]))

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -70,7 +70,9 @@ def test_predict_all_items(train_test_dummy_timestamp, header):
     trainset, _ = train_test_dummy_timestamp
     model.fit(trainset)
 
-    user_items = itertools.product(trainset[header["col_user"]].unique(), trainset[header["col_item"]].unique())
+    user_items = itertools.product(
+        trainset[header["col_user"]].unique(), trainset[header["col_item"]].unique()
+    )
     testset = pd.DataFrame(user_items, columns=[header["col_user"], header["col_item"]])
     preds = model.predict(testset)
 
@@ -207,19 +209,44 @@ def test_recommend_similar_items(header, pandas_dummy):
     sar.fit(pandas_dummy)
 
     # test with just items provided
-    expected = pd.DataFrame(dict(UserId=[0, 0, 0], MovieId=[8, 7, 6], prediction=[2.0, 2.0, 2.0]))
+    expected = pd.DataFrame(
+        dict(UserId=[0, 0, 0], MovieId=[8, 7, 6], prediction=[2.0, 2.0, 2.0])
+    )
     items = pd.DataFrame({header["col_item"]: [1, 5, 10]})
     actual = sar.recommend_similar_items(items, top_k=3)
     assert_frame_equal(expected, actual)
 
     # test with items and users
-    expected = pd.DataFrame(dict(UserId=[100, 100, 100, 1, 1, 1], MovieId=[8, 7, 6, 10, 4, 3], prediction=[2.0, 2.0, 2.0, 1.0, 2.0, 2.0]))
-    items = pd.DataFrame({header["col_user"]: [100, 100, 1, 100, 1, 1], header["col_item"]: [1, 5, 1, 10, 2, 6]})
+    expected = pd.DataFrame(
+        dict(
+            UserId=[100, 100, 100, 1, 1, 1],
+            MovieId=[8, 7, 6, 10, 4, 3],
+            prediction=[2.0, 2.0, 2.0, 1.0, 2.0, 2.0],
+        )
+    )
+    items = pd.DataFrame(
+        {
+            header["col_user"]: [100, 100, 1, 100, 1, 1],
+            header["col_item"]: [1, 5, 1, 10, 2, 6],
+        }
+    )
     actual = sar.recommend_similar_items(items, top_k=3)
     assert_frame_equal(expected, actual)
 
     # test with items, users, and ratings
-    expected = pd.DataFrame(dict(UserId=[100, 100, 100, 1, 1, 1], MovieId=[2, 4, 3, 10, 4, 3], prediction=[5.0, 5.0, 5.0, 4.0, 8.0, 8.0]))
-    items = pd.DataFrame({header["col_user"]: [100, 100, 1, 100, 1, 1], header["col_item"]: [1, 5, 1, 10, 2, 6], header["col_rating"]: [5, 1, 3, 1, 5, 4]})
+    expected = pd.DataFrame(
+        dict(
+            UserId=[100, 100, 100, 1, 1, 1],
+            MovieId=[2, 4, 3, 10, 4, 3],
+            prediction=[5.0, 5.0, 5.0, 4.0, 8.0, 8.0],
+        )
+    )
+    items = pd.DataFrame(
+        {
+            header["col_user"]: [100, 100, 1, 100, 1, 1],
+            header["col_item"]: [1, 5, 1, 10, 2, 6],
+            header["col_rating"]: [5, 1, 3, 1, 5, 4],
+        }
+    )
     actual = sar.recommend_similar_items(items, top_k=3)
     assert_frame_equal(expected, actual)

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -206,21 +206,20 @@ def test_recommend_similar_items(header, pandas_dummy):
     sar = SARSingleNode(**header)
     sar.fit(pandas_dummy)
 
-    # FIXME: confirm values for items and predictions (print out item similarity)
     # test with just items provided
-    expected = pd.DataFrame(dict(UserId=[0, 0, 0], MovieId=[8, 7, 6], prediction=[2., 2., 2.]))
+    expected = pd.DataFrame(dict(UserId=[0, 0, 0], MovieId=[8, 7, 6], prediction=[2.0, 2.0, 2.0]))
     items = pd.DataFrame({header["col_item"]: [1, 5, 10]})
     actual = sar.recommend_similar_items(items, top_k=3)
     assert_frame_equal(expected, actual)
 
     # test with items and users
-    expected = pd.DataFrame(dict(UserId=[100, 100, 100, 1, 1, 1], MovieId=[2, 4, 3, 6, 4, 1], prediction=[2.0, 2.0, 2.0, 1.0, 2.0, 2.0]))
-    items = pd.DataFrame({header["col_user"]: [100, 100, 1, 100, 1, 1], header["col_item"]: [1, 5, 10, 1, 2, 3]})
+    expected = pd.DataFrame(dict(UserId=[100, 100, 100, 1, 1, 1], MovieId=[8, 7, 6, 10, 4, 3], prediction=[2.0, 2.0, 2.0, 1.0, 2.0, 2.0]))
+    items = pd.DataFrame({header["col_user"]: [100, 100, 1, 100, 1, 1], header["col_item"]: [1, 5, 1, 10, 2, 6]})
     actual = sar.recommend_similar_items(items, top_k=3)
     assert_frame_equal(expected, actual)
 
     # test with items, users, and ratings
-    expected = pd.DataFrame(dict(UserId=[100, 100, 100, 1, 1, 1], MovieId=[2, 4, 10, 6, 4, 1], prediction=[2.0, 2.0, 2.0, 3.0, 9.0, 9.0]))
-    items = pd.DataFrame({header["col_user"]: [100, 100, 1, 100, 1, 1], header["col_item"]: [1, 5, 10, 1, 2, 3], header["col_rating"]: [1, 2, 3, 1, 5, 4]})
+    expected = pd.DataFrame(dict(UserId=[100, 100, 100, 1, 1, 1], MovieId=[2, 4, 3, 10, 4, 3], prediction=[5.0, 5.0, 5.0, 4.0, 8.0, 8.0]))
+    items = pd.DataFrame({header["col_user"]: [100, 100, 1, 100, 1, 1], header["col_item"]: [1, 5, 1, 10, 2, 6], header["col_rating"]: [5, 1, 3, 1, 5, 4]})
     actual = sar.recommend_similar_items(items, top_k=3)
     assert_frame_equal(expected, actual)

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -230,15 +230,15 @@ def test_recommend_similar_items(header, pandas_dummy):
             header["col_item"]: [1, 5, 1, 10, 2, 6],
         }
     )
-    actual = sar.recommend_similar_items(items, top_k=3)
+    actual = sar.recommend_similar_items(items, top_k=3, sort_top_k=True)
     assert_frame_equal(expected, actual)
 
     # test with items, users, and ratings
     expected = pd.DataFrame(
         dict(
             UserId=[100, 100, 100, 1, 1, 1],
-            MovieId=[2, 4, 3, 10, 4, 3],
-            prediction=[5.0, 5.0, 5.0, 4.0, 8.0, 8.0],
+            MovieId=[2, 4, 3, 4, 3, 10],
+            prediction=[5.0, 5.0, 5.0, 8.0, 8.0, 4.0],
         )
     )
     items = pd.DataFrame(
@@ -249,4 +249,24 @@ def test_recommend_similar_items(header, pandas_dummy):
         }
     )
     actual = sar.recommend_similar_items(items, top_k=3)
+    assert_frame_equal(expected, actual)
+
+
+def test_recommend_popular_items(header):
+
+    train_df = pd.DataFrame(
+        {
+            header["col_user"]: [1, 1, 1, 2, 2, 2, 3, 3, 3],
+            header["col_item"]: [1, 2, 3, 1, 3, 4, 5, 6, 1],
+            header["col_rating"]: [1, 2, 3, 1, 2, 3, 1, 2, 3]
+        }
+    )
+
+    sar = SARSingleNode(**header)
+    sar.fit(train_df)
+
+    expected = pd.DataFrame(
+        dict(UserId=[0, 0, 0], MovieId=[1, 3, 4], prediction=[3, 2, 1])
+    )
+    actual = sar.recommend_popular_items(top_k=3, sort_top_k=True)
     assert_frame_equal(expected, actual)


### PR DESCRIPTION
### Description
Addition of similar item recommendations to SAR implementation
This lets you create a set of seed items and get the top-k recommended items similar to that set of items (excluding the ones provided).
You can put in multiple seed sets by adding a user column, and you can weight the seeds by providing a rating column as well.
This essentially provides a way to generate top-k recommendations for new users, but does not update the model.

```
    sar = SARSingleNode()
    sar.fit(data)

    items = pd.DataFrame(dict(itemID=[1, 5, 10]))
    results = sar.recommend_similar_items(items, top_k=3)
```

results will be a dataframe with user, item and prediction columns (user is 0 unless multiple users are provided in items dataframe)


### Related Issues
#549 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [x] I have added tests.
- [x] I have updated the documentation accordingly.
