### PR TITLE
fixing conda install script to be python2 compliant

### DIFF
--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -158,10 +158,12 @@ if __name__ == "__main__":
     # check for os platform support
     if platform == 'darwin':
         pip_packages.update(PIP_DARWIN)
-    if platform == 'linux':
+    elif platform.startswith('linux'):
         pip_packages.update(PIP_LINUX)
-    if platform == 'win32':
+    elif platform == 'win32':
         pip_packages.update(PIP_WIN32)
+    else:
+        raise Exception('Unsupported platform, must be Windows, Linux, or macOS')
 
     # write out yaml file
     conda_file = "{}.yaml".format(conda_env)


### PR DESCRIPTION
### Description
generate_conda_file.py was using platform values corresponding to python 3, which changed slightly from what was used in python 2 (https://docs.python.org/2/library/sys.html), adjusting this code to be python2 and 3 compatible in case the initial installation is using legacy python.


### Related Issues
#775 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



