### PR TITLE
update sar deep dive to use stratified split to avoid cold start user…

### DIFF
--- a/notebooks/02_model/sar_deep_dive.ipynb
+++ b/notebooks/02_model/sar_deep_dive.ipynb
@@ -112,7 +112,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "System version: 3.6.8 |Anaconda, Inc.| (default, Feb 21 2019, 18:30:04) [MSC v.1916 64 bit (AMD64)]\n",
+      "System version: 3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34) \n",
+      "[GCC 7.3.0]\n",
       "Pandas version: 0.24.2\n"
      ]
     }
@@ -131,7 +132,7 @@
     "import papermill as pm\n",
     "\n",
     "from reco_utils.dataset import movielens\n",
-    "from reco_utils.dataset.python_splitters import python_random_split\n",
+    "from reco_utils.dataset.python_splitters import python_stratified_split\n",
     "from reco_utils.evaluation.python_evaluation import map_at_k, ndcg_at_k, precision_at_k, recall_at_k\n",
     "from reco_utils.recommender.sar.sar_singlenode import SARSingleNode\n",
     "\n",
@@ -179,7 +180,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "4.93MB [00:00, 5.32MB/s]                                                                                                                                                                                                                                                   \n"
+      "4.93MB [00:02, 2.36MB/s]                            \n"
      ]
     },
     {
@@ -288,21 +289,12 @@
    "source": [
     "### 3.2 Split the data using the python random splitter provided in utilities:\n",
     "\n",
-    "We utilize the provided `python_random_split` function to split into `train` and `test` datasets randomly at a 75/25 ratio."
+    "We split the full dataset into a `train` and `test` dataset to evaluate performance of the algorithm against a held-out set not seen during training. Because SAR generates recommendations based on user preferences, all users that are in the test set must also exist in the training set. For this case, we can use the provided `python_stratified_split` function which holds out a percentage (in this case 25%) of items from each user, but ensures all users are in both `train` and `test` datasets. Other options are available in the `dataset.python_splitters` module which provide more control over how the split occurs.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train, test = python_random_split(data, 0.75)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,6 +305,15 @@
     "    \"col_timestamp\": \"Timestamp\",\n",
     "    \"col_prediction\": \"Prediction\",\n",
     "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train, test = python_stratified_split(data, ratio=0.75, col_user=header[\"col_user\"], col_item=header[\"col_item\"], seed=42)"
    ]
   },
   {
@@ -357,14 +358,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-04-23 12:43:08,525 INFO     Collecting user affinity matrix\n",
-      "2019-04-23 12:43:08,530 INFO     Calculating time-decayed affinities\n",
-      "2019-04-23 12:43:08,581 INFO     Creating index columns\n",
-      "2019-04-23 12:43:08,609 INFO     Building user affinity sparse matrix\n",
-      "2019-04-23 12:43:08,617 INFO     Calculating item co-occurrence\n",
-      "2019-04-23 12:43:08,785 INFO     Calculating item similarity\n",
-      "2019-04-23 12:43:08,787 INFO     Using jaccard based similarity\n",
-      "2019-04-23 12:43:08,947 INFO     Done training\n"
+      "2019-05-28 22:40:09,133 INFO     Collecting user affinity matrix\n",
+      "2019-05-28 22:40:09,137 INFO     Calculating time-decayed affinities\n",
+      "2019-05-28 22:40:09,178 INFO     Creating index columns\n",
+      "2019-05-28 22:40:09,188 INFO     Building user affinity sparse matrix\n",
+      "2019-05-28 22:40:09,194 INFO     Calculating item co-occurrence\n",
+      "2019-05-28 22:40:09,412 INFO     Calculating item similarity\n",
+      "2019-05-28 22:40:09,413 INFO     Using jaccard based similarity\n",
+      "2019-05-28 22:40:09,534 INFO     Done training\n"
      ]
     }
    ],
@@ -383,8 +384,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2019-04-23 12:43:08,957 INFO     Calculating recommendation scores\n",
-      "2019-04-23 12:43:09,050 INFO     Removing seen items\n"
+      "2019-05-28 22:40:09,546 INFO     Calculating recommendation scores\n",
+      "2019-05-28 22:40:09,641 INFO     Removing seen items\n"
      ]
     }
    ],
@@ -435,91 +436,91 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>4678</th>\n",
-       "      <td>943</td>\n",
-       "      <td>385</td>\n",
-       "      <td>22.063621</td>\n",
-       "      <td>True Lies (1994)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4674</th>\n",
-       "      <td>943</td>\n",
-       "      <td>79</td>\n",
-       "      <td>20.945250</td>\n",
-       "      <td>Fugitive, The (1993)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4675</th>\n",
-       "      <td>943</td>\n",
-       "      <td>69</td>\n",
-       "      <td>20.665495</td>\n",
-       "      <td>Forrest Gump (1994)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4671</th>\n",
+       "      <th>9424</th>\n",
        "      <td>943</td>\n",
        "      <td>82</td>\n",
-       "      <td>20.615830</td>\n",
+       "      <td>21.313228</td>\n",
        "      <td>Jurassic Park (1993)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4676</th>\n",
-       "      <td>943</td>\n",
-       "      <td>202</td>\n",
-       "      <td>20.333979</td>\n",
-       "      <td>Groundhog Day (1993)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4672</th>\n",
-       "      <td>943</td>\n",
-       "      <td>550</td>\n",
-       "      <td>20.223571</td>\n",
-       "      <td>Die Hard: With a Vengeance (1995)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4677</th>\n",
-       "      <td>943</td>\n",
-       "      <td>265</td>\n",
-       "      <td>20.060790</td>\n",
-       "      <td>Hunt for Red October, The (1990)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4679</th>\n",
-       "      <td>943</td>\n",
-       "      <td>183</td>\n",
-       "      <td>19.947005</td>\n",
-       "      <td>Alien (1979)</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4673</th>\n",
+       "      <th>9425</th>\n",
        "      <td>943</td>\n",
        "      <td>403</td>\n",
-       "      <td>19.897583</td>\n",
+       "      <td>21.158839</td>\n",
        "      <td>Batman (1989)</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4670</th>\n",
+       "      <th>9426</th>\n",
        "      <td>943</td>\n",
-       "      <td>168</td>\n",
-       "      <td>19.895860</td>\n",
-       "      <td>Monty Python and the Holy Grail (1974)</td>\n",
+       "      <td>568</td>\n",
+       "      <td>20.962922</td>\n",
+       "      <td>Speed (1994)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9428</th>\n",
+       "      <td>943</td>\n",
+       "      <td>423</td>\n",
+       "      <td>20.162170</td>\n",
+       "      <td>E.T. the Extra-Terrestrial (1982)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9427</th>\n",
+       "      <td>943</td>\n",
+       "      <td>89</td>\n",
+       "      <td>19.890513</td>\n",
+       "      <td>Blade Runner (1982)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9429</th>\n",
+       "      <td>943</td>\n",
+       "      <td>393</td>\n",
+       "      <td>19.832944</td>\n",
+       "      <td>Mrs. Doubtfire (1993)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9423</th>\n",
+       "      <td>943</td>\n",
+       "      <td>11</td>\n",
+       "      <td>19.570244</td>\n",
+       "      <td>Seven (Se7en) (1995)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9422</th>\n",
+       "      <td>943</td>\n",
+       "      <td>71</td>\n",
+       "      <td>19.553877</td>\n",
+       "      <td>Lion King, The (1994)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9421</th>\n",
+       "      <td>943</td>\n",
+       "      <td>202</td>\n",
+       "      <td>19.422129</td>\n",
+       "      <td>Groundhog Day (1993)</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9420</th>\n",
+       "      <td>943</td>\n",
+       "      <td>238</td>\n",
+       "      <td>19.115604</td>\n",
+       "      <td>Raising Arizona (1987)</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      UserId  MovieId  Prediction                                   Title\n",
-       "4678     943      385   22.063621                        True Lies (1994)\n",
-       "4674     943       79   20.945250                    Fugitive, The (1993)\n",
-       "4675     943       69   20.665495                     Forrest Gump (1994)\n",
-       "4671     943       82   20.615830                    Jurassic Park (1993)\n",
-       "4676     943      202   20.333979                    Groundhog Day (1993)\n",
-       "4672     943      550   20.223571       Die Hard: With a Vengeance (1995)\n",
-       "4677     943      265   20.060790        Hunt for Red October, The (1990)\n",
-       "4679     943      183   19.947005                            Alien (1979)\n",
-       "4673     943      403   19.897583                           Batman (1989)\n",
-       "4670     943      168   19.895860  Monty Python and the Holy Grail (1974)"
+       "      UserId  MovieId  Prediction                              Title\n",
+       "9424     943       82   21.313228               Jurassic Park (1993)\n",
+       "9425     943      403   21.158839                      Batman (1989)\n",
+       "9426     943      568   20.962922                       Speed (1994)\n",
+       "9428     943      423   20.162170  E.T. the Extra-Terrestrial (1982)\n",
+       "9427     943       89   19.890513                Blade Runner (1982)\n",
+       "9429     943      393   19.832944              Mrs. Doubtfire (1993)\n",
+       "9423     943       11   19.570244               Seven (Se7en) (1995)\n",
+       "9422     943       71   19.553877              Lion King, The (1994)\n",
+       "9421     943      202   19.422129               Groundhog Day (1993)\n",
+       "9420     943      238   19.115604             Raising Arizona (1987)"
       ]
      },
      "metadata": {},
@@ -576,10 +577,10 @@
      "text": [
       "Model:\n",
       "Top K:\t\t 10\n",
-      "MAP:\t\t 0.103501\n",
-      "NDCG:\t\t 0.368105\n",
-      "Precision@K:\t 0.317603\n",
-      "Recall@K:\t 0.169709\n"
+      "MAP:\t\t 0.095544\n",
+      "NDCG:\t\t 0.350232\n",
+      "Precision@K:\t 0.305726\n",
+      "Recall@K:\t 0.164690\n"
      ]
     }
    ],


### PR DESCRIPTION
# Follow up to #773 - consistency in sampling approach to SAR deep dive notebook

### Description

Changed the SAR deep dive notebook to use stratified sampling to a) avoid new users in the test dataset and b) be consistent with the quick start notebook.

### Related Issues


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.