### PR TITLE
DATA: optimize splitting performance

### DIFF
--- a/reco_utils/dataset/spark_splitters.py
+++ b/reco_utils/dataset/spark_splitters.py
@@ -149,8 +149,6 @@ def spark_stratified_split(
     Returns:
         list: Splits of the input data as spark.DataFrame.
     """
-    from pyspark.sql.functions import collect_list, size
-
     if not (filter_by == "user" or filter_by == "item"):
         raise ValueError("filter_by should be either 'user' or 'item'.")
 

--- a/reco_utils/dataset/spark_splitters.py
+++ b/reco_utils/dataset/spark_splitters.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from pyspark.sql import Window
-from pyspark.sql.functions import col, row_number, broadcast, rand
+from pyspark.sql.functions import col, row_number, broadcast, rand, collect_list, size
 
 from reco_utils.common.constants import (
     DEFAULT_ITEM_COL,
@@ -93,14 +93,10 @@ def spark_chrono_split(
     ratio = ratio if multi_split else [ratio, 1 - ratio]
     ratio_index = np.cumsum(ratio)
 
+    window_count = Window.partitionBy(split_by_column)
     window_spec = Window.partitionBy(split_by_column).orderBy(col(col_timestamp))
 
-    rating_grouped = (
-        data.groupBy(split_by_column)
-        .agg({col_timestamp: "count"})
-        .withColumnRenamed("count(" + col_timestamp + ")", "count")
-    )
-    rating_all = data.join(broadcast(rating_grouped), on=split_by_column)
+    rating_all = data.withColumn('count', size(collect_list(col_timestamp).over(window_count)))
 
     rating_rank = rating_all.withColumn(
         "rank", row_number().over(window_spec) / col("count")
@@ -153,6 +149,8 @@ def spark_stratified_split(
     Returns:
         list: Splits of the input data as spark.DataFrame.
     """
+    from pyspark.sql.functions import collect_list, size
+
     if not (filter_by == "user" or filter_by == "item"):
         raise ValueError("filter_by should be either 'user' or 'item'.")
 
@@ -175,15 +173,10 @@ def spark_stratified_split(
     ratio = ratio if multi_split else [ratio, 1 - ratio]
     ratio_index = np.cumsum(ratio)
 
+    window_count = Window.partitionBy(split_by_column)
     window_spec = Window.partitionBy(split_by_column).orderBy(rand(seed=seed))
 
-    rating_grouped = (
-        data.groupBy(split_by_column)
-        .agg({col_rating: "count"})
-        .withColumnRenamed("count(" + col_rating + ")", "count")
-    )
-    rating_all = data.join(broadcast(rating_grouped), on=split_by_column)
-
+    rating_all = data.withColumn('count', size(collect_list(col_rating).over(window_count)))
     rating_rank = rating_all.withColumn(
         "rank", row_number().over(window_spec) / col("count")
     )


### PR DESCRIPTION
### Description
The creation of the PR is based on a discussion with a user of the repo, who found it time-consuming for splitting dataframe with stratification in Spark. 

The PR optimizes the Spark-based splitter implementation by removing the unnessary `join` operations in DataFrames. This reduced the time for unit test of, for example, `spark_stratified_splitter`, from 8.77 sec to 2.77 sec.

### Related Issues
N/A

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.