### PR TITLE
adding marker to skip vw tests if necessary

### DIFF
--- a/tests/integration/test_notebooks_python.py
+++ b/tests/integration/test_notebooks_python.py
@@ -115,6 +115,7 @@ def test_surprise_svd_integration(notebooks, size, expected_values):
         assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
+@pytest.mark.vw
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "size, expected_values",

--- a/tests/smoke/test_notebooks_python.py
+++ b/tests/smoke/test_notebooks_python.py
@@ -72,6 +72,7 @@ def test_surprise_svd_smoke(notebooks):
     assert results["recall"] == pytest.approx(0.032, rel=TOL, abs=ABS_TOL)
 
 
+@pytest.mark.vw
 @pytest.mark.smoke
 def test_vw_deep_dive_smoke(notebooks):
     notebook_path = notebooks["vowpal_wabbit_deep_dive"]

--- a/tests/unit/test_notebooks_python.py
+++ b/tests/unit/test_notebooks_python.py
@@ -47,6 +47,7 @@ def test_surprise_deep_dive_runs(notebooks):
     pm.execute_notebook(notebook_path, OUTPUT_NOTEBOOK, kernel_name=KERNEL_NAME)
 
 
+@pytest.mark.vw
 @pytest.mark.notebooks
 def test_vw_deep_dive_runs(notebooks):
     notebook_path = notebooks["vowpal_wabbit_deep_dive"]

--- a/tests/unit/test_vowpal_wabbit.py
+++ b/tests/unit/test_vowpal_wabbit.py
@@ -25,6 +25,7 @@ def model():
     del model
 
 
+@pytest.mark.vw
 def test_vw_init_del():
     model = VW()
     tempdir = model.tempdir.name
@@ -34,6 +35,7 @@ def test_vw_init_del():
     assert not os.path.exists(tempdir)
 
 
+@pytest.mark.vw
 def test_to_vw_cmd():
     expected = [
         "vw",
@@ -60,6 +62,7 @@ def test_to_vw_cmd():
     assert VW.to_vw_cmd(params=params) == expected
 
 
+@pytest.mark.vw
 def test_parse_train_cmd(model):
     expected = [
         "vw",
@@ -76,6 +79,7 @@ def test_parse_train_cmd(model):
     assert model.parse_train_params(params=params) == expected
 
 
+@pytest.mark.vw
 def test_parse_test_cmd(model):
     expected = [
         "vw",
@@ -96,6 +100,7 @@ def test_parse_test_cmd(model):
     assert model.parse_test_params(params=params) == expected
 
 
+@pytest.mark.vw
 def test_to_vw_file(model, df):
     expected = ["1 0|user 1 |item 8", "5 1|user 3 |item 7", "3 2|user 2 |item 7"]
     model.to_vw_file(df, train=True)
@@ -104,6 +109,7 @@ def test_to_vw_file(model, df):
     del model
 
 
+@pytest.mark.vw
 def test_fit_and_predict(model, df):
     # generate fake predictions
     with open(model.prediction_file, "w") as f:


### PR DESCRIPTION
### Description
new devops setup has the tests run on machines without vw installed. until that can be sorted out we are adding an optional marker which will allow all vw related tests to be skipped by using -k "not vw" in the pytest command.

### Related Issues



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [X] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.