### PR TITLE
Best-practices devops: Increase max timeout for nightly_gpu integration tests

### DIFF
--- a/tests/ci/nightly_gpu.yml
+++ b/tests/ci/nightly_gpu.yml
@@ -13,7 +13,6 @@ variables:
   dockerproc : 'gpu'
 
 trigger: none
-
 pr: none
 
 jobs:
@@ -62,7 +61,7 @@ jobs:
 - job : Integration
   dependsOn: Smoke
   condition: succeeded('Smoke')
-  timeoutInMinutes: 90
+  timeoutInMinutes: 150
   displayName : 'Integration: Nightly_gpu_test'
   
   pool:


### PR DESCRIPTION
### Description
The max length of time allocated for the integration test was increased as it was too short.


### Related Issues


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.