### PR TITLE
Spark movielens bug fix

### DIFF
--- a/reco_utils/dataset/movielens.py
+++ b/reco_utils/dataset/movielens.py
@@ -459,7 +459,7 @@ def _get_schema(header, schema):
     if schema is None or len(schema) == 0:
         # Use header to generate schema
         if header is None or len(header) == 0:
-            return DEFAULT_HEADER
+            header = DEFAULT_HEADER
         elif len(header) > 4:
             warnings.warn(WARNING_MOVIE_LENS_HEADER)
             header = header[:4]


### PR DESCRIPTION
### Description
`_get_schema` should return spark schema object, but the previous change made it to return a string list (pandas header). This PR fixes the bug.

### Related Issues
#871

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.