### PR TITLE
Improve SAR performance

### DIFF
--- a/reco_utils/recommender/sar/sar_singlenode.py
+++ b/reco_utils/recommender/sar/sar_singlenode.py
@@ -244,18 +244,21 @@ class SARSingleNode:
                 temp_df = self.compute_time_decay(df=temp_df, decay_column=self.col_unity_rating)
             self.unity_user_affinity = self.compute_affinity_matrix(df=temp_df, rating_col=self.col_unity_rating)
 
-        # retain seen items for removal at prediction time
-        self.seen_items = temp_df[[self.col_user_id, self.col_item_id]].values
-
         # affinity matrix
         logger.info("Building user affinity sparse matrix")
         self.user_affinity = self.compute_affinity_matrix(df=temp_df, rating_col=self.col_rating)
+
+        # retain seen items for removal at prediction time
+        seen = temp_df[[self.col_user_id, self.col_item_id]].values
+        self.seen_items = np.ones(self.user_affinity.shape)
+        self.seen_items[seen[:, 0], seen[:, 1]] = -np.inf
 
         # calculate item co-occurrence
         logger.info("Calculating item co-occurrence")
         item_cooccurrence = self.compute_coocurrence_matrix(df=temp_df)
 
         # free up some space
+        del seen
         del temp_df
 
         self.item_frequencies = item_cooccurrence.diagonal()
@@ -301,19 +304,16 @@ class SARSingleNode:
 
         # calculate raw scores with a matrix multiplication
         logger.info("Calculating recommendation scores")
-        # TODO: only compute scores for users in test
-        test_scores = self.user_affinity.dot(self.item_similarity)
-
-        # remove items in the train set so recommended items are always novel
-        if remove_seen:
-            logger.info("Removing seen items")
-            test_scores[self.seen_items[:, 0], self.seen_items[:, 1]] = -np.inf
-
-        test_scores = test_scores[user_ids, :]
+        test_scores = self.user_affinity[user_ids, :].dot(self.item_similarity)
 
         # ensure we're working with a dense ndarray
         if isinstance(test_scores, sparse.spmatrix):
             test_scores = test_scores.toarray()
+
+        # remove items in the train set so recommended items are always novel
+        if remove_seen:
+            logger.info("Removing seen items")
+            test_scores = test_scores * self.seen_items[user_ids, :]
 
         if normalize:
             if self.unity_user_affinity is None:


### PR DESCRIPTION
Co-authored-by: @Overv

### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
During production implementation of the SAR recommender algorithm, we were facing severe performance issues. This was the result of calculating recommendations for all users in the entire set, despite only requiring recommendations for one user.

The approach that was taken during the initial implementation allowed for easy removal of previously 'seen items'.

We changed the size of the affinity matrix that is used for the calculations, by only keeping the rows for the users in the test set, as follows:

https://github.com/microsoft/recommenders/blob/4c875df2d0b6b3ddad70a49a4353c5de19c28e61/reco_utils/recommender/sar/sar_singlenode.py#L307

To be able to do the same thing with the seen-items matrix, we needed to reshape it to reflect the affinity matrix, as follows:

https://github.com/microsoft/recommenders/blob/4c875df2d0b6b3ddad70a49a4353c5de19c28e61/reco_utils/recommender/sar/sar_singlenode.py#L252-L254

To follow the conventions set in the repo, we also clean up the `seen`-variable during model fitting.

https://github.com/microsoft/recommenders/blob/4c875df2d0b6b3ddad70a49a4353c5de19c28e61/reco_utils/recommender/sar/sar_singlenode.py#L260-L261

This then allows us to do the following, when the `remove_seen` arg is `True`:

https://github.com/microsoft/recommenders/blob/4c875df2d0b6b3ddad70a49a4353c5de19c28e61/reco_utils/recommender/sar/sar_singlenode.py#L314-L316

The resulting matrix then has all previously seen items set to `-np.inf`. The result gets cleaned up, as follows (not part of our PR):

https://github.com/microsoft/recommenders/blob/4c875df2d0b6b3ddad70a49a4353c5de19c28e61/reco_utils/recommender/sar/sar_singlenode.py#L457-L458

#### Performance
The performance improvement seen is significant, as summarized in the following table:

| remove_seen 	|     Original    	|     Optimized     	| Improvement 	|
|-----------:	|---------------:	|-----------------:	|--------------------:	|
|        **True** 	| 3.83 s ± 459 ms 	| 17.5 ms ± 1.06 ms 	|                 219x 	|
|       **False** 	| 3.42 s ± 468 ms 	|  17.9 ms ± 1.7 ms 	|                 191x 	|

_This analysis was done on our production dataset of approx. 500K rows._

We have not investigated the difference in training time.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/recommenders/issues/907

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.