### PR TITLE
Missing newline in predict() output file at the end of every batch

### DIFF
--- a/reco_utils/recommender/deeprec/models/base_model.py
+++ b/reco_utils/recommender/deeprec/models/base_model.py
@@ -501,7 +501,6 @@ class BaseModel:
                 step_pred = self.infer(load_sess, batch_data_input)
                 step_pred = np.reshape(step_pred, -1)
                 wt.write("\n".join(map(str, step_pred)))
-
-            # line break after each batch.
-            wt.write("\n")
+                # line break after each batch.
+                wt.write("\n")
         return self


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
We noticed that the number of predictions in the file does not match the number of examples presented to the predict() method. Upon examining the output file we notice that there is a missing newline at the batch_size row which results in two predictions being output on the same line. The same situation occurs at every batch_size boundary.
<!--- Why is this change required? What problem does it solve? -->
Without this fix it is not possible to line up the prediction examples with the predictions without manually editing the output file and adding newlines as needed.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
This is a fix for #961. The original issue was found in #782 and fixed in #833 but the fix was immediately overwritten by the next commit.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.