### PR TITLE
Update generate_conda_file.py

### DIFF
--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -57,13 +57,13 @@ CONDA_BASE = {
     "lightgbm": "lightgbm==2.2.1",
     "cmake": "cmake==3.14.0",
     "cornac": "cornac>=1.1.2",
-    "fastai": "fastai==1.0.46",
     "papermill": "papermill==0.19.1",
 }
 
 CONDA_PYSPARK = {"pyarrow": "pyarrow>=0.8.0", "pyspark": "pyspark==2.3.1"}
 
 CONDA_GPU = {
+    "fastai": "fastai==1.0.46",
     "numba": "numba>=0.38.1",
     "pytorch": "pytorch>=1.0.0",
     "tensorflow": "tensorflow-gpu==1.12.0",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

I hit a strange error when running the CPU Unit Tests.

"ERROR: fastai 1.0.46 requires nvidia-ml-py3, which is not installed."

It looks like "fastai" is in the conda base. But "nvidia-ml-py3", is only included in the the GPU image. I think fastai should be moved into CONDA_GPU.

Here is a PR that makes the change.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.