### PR TITLE
if exist folder, delete it 

### DIFF
--- a/tests/ci/azure_pipeline_test/dsvm_nightly_win_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_win_cpu.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
   - script: |
       call conda env remove -n nightly_reco_base -y
-      rmdir /s /q C:\Anaconda\envs\nightly_reco_base
+      if exist C:\Anaconda\envs\nightly_reco_base rmdir /s /q C:\Anaconda\envs\nightly_reco_base
     displayName: 'Remove Conda Env if it exists'
 
   - script: |

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_win_gpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_win_gpu.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
   - script: |
       call conda env remove -n nightly_reco_gpu -y
-      rmdir /s /q C:\Anaconda\envs\nightly_reco_gpu
+      if exist C:\Anaconda\envs\nightly_reco_gpu rmdir /s /q C:\Anaconda\envs\nightly_reco_gpu
     displayName: 'Remove Conda Env if it exists'
 
   - script: |

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_win_pyspark.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_win_pyspark.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
   - script: |
       call conda env remove -n nightly_reco_pyspark -y
-      rmdir /s /q C:\Anaconda\envs\nightly_reco_pyspark
+      if exist C:\Anaconda\envs\nightly_reco_pyspark rmdir /s /q C:\Anaconda\envs\nightly_reco_pyspark
     displayName: 'Remove Conda Env if it exists'
 
   - script: |


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The windows nightly builds were failing because of not managing well when removing the conda folder, see failure here: https://dev.azure.com/best-practices/recommenders/_build/results?buildId=16113

```
##[section]Starting: Remove Conda Env if it exists
==============================================================================
Task         : Command line
Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
Version      : 2.151.2
Author       : Microsoft Corporation
Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
==============================================================================
Generating script.
========================== Starting Command Output ===========================
##[command]"C:\windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "C:\Users\recocat\agent\_work\_temp\d909c98a-ca04-40a8-8419-094fc70e6384.cmd""
The system cannot find the file specified.
##[error]Cmd.exe exited with code '2'.
##[section]Finishing: Remove Conda Env if it exists
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.