### PR TITLE
force to remove the conda env always in the nightly builds

### DIFF
--- a/tests/ci/azure_pipeline_test/dsvm_nightly_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_linux_cpu.yml
@@ -54,4 +54,4 @@ jobs:
     workingDirectory: tests
     displayName: 'Conda remove'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: always() # this step will always run, even if the pipeline is canceled

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_linux_gpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_linux_gpu.yml
@@ -54,5 +54,5 @@ jobs:
     workingDirectory: tests
     displayName: 'Conda remove'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: always() # this step will always run, even if the pipeline is canceled
 

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_linux_pyspark.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_linux_pyspark.yml
@@ -54,4 +54,4 @@ jobs:
     workingDirectory: tests
     displayName: 'Conda remove'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: always() # this step will always run, even if the pipeline is canceled

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_win_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_win_cpu.yml
@@ -47,11 +47,11 @@ jobs:
 
   - script: |
       call conda env remove -n nightly_reco_base -y
-      rmdir /s /q C:\Anaconda\envs\nightly_reco_base
+      if exist C:\Anaconda\envs\nightly_reco_base rmdir /s /q C:\Anaconda\envs\nightly_reco_base
     workingDirectory: tests
     displayName: 'Conda remove'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: always() # this step will always run, even if the pipeline is canceled
 
   - script: |
       del /q /S %LOCALAPPDATA%\Temp\*

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_win_gpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_win_gpu.yml
@@ -47,7 +47,8 @@ jobs:
 
   - script: |
       call conda env remove -n nightly_reco_gpu -y
-      rmdir /s /q C:\Anaconda\envs\nightly_reco_gpu
+      if exist C:\Anaconda\envs\nightly_reco_gpu rmdir /s /q C:\Anaconda\envs\nightly_reco_gpu
     workingDirectory: tests
     displayName: 'Conda remove'
     continueOnError: true
+    condition: always() # this step will always run, even if the pipeline is canceled

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_win_pyspark.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_win_pyspark.yml
@@ -51,9 +51,9 @@ jobs:
 
   - script: |
       call conda env remove -n nightly_reco_pyspark -y
-      rmdir /s /q C:\Anaconda\envs\nightly_reco_pyspark
+      if exist C:\Anaconda\envs\nightly_reco_pyspark rmdir /s /q C:\Anaconda\envs\nightly_reco_pyspark
     workingDirectory: tests
     displayName: 'Conda remove'
     continueOnError: true
-    condition: succeededOrFailed()
+    condition: always() # this step will always run, even if the pipeline is canceled
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Minor edit, to make sure that the conda env is always erased after the nightly builds are computed

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.