### PR TITLE
fix for Issue #970

### DIFF
--- a/reco_utils/recommender/deeprec/models/base_model.py
+++ b/reco_utils/recommender/deeprec/models/base_model.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+from os.path import join
 import abc
 import time
 import numpy as np
@@ -406,7 +407,7 @@ class BaseModel:
 
             if self.hparams.save_model:
                 if epoch % self.hparams.save_epoch == 0:
-                    save_path_str = self.hparams.MODEL_DIR + "/" + "epoch_" + str(epoch)
+                    save_path_str = join(self.hparams.MODEL_DIR, "epoch_" + str(epoch))
                     checkpoint_path = self.saver.save(
                         sess=train_sess,
                         save_path = save_path_str,

--- a/reco_utils/recommender/deeprec/models/base_model.py
+++ b/reco_utils/recommender/deeprec/models/base_model.py
@@ -406,9 +406,10 @@ class BaseModel:
 
             if self.hparams.save_model:
                 if epoch % self.hparams.save_epoch == 0:
+                    save_path_str = self.hparams.MODEL_DIR + "/" + "epoch_" + str(epoch)
                     checkpoint_path = self.saver.save(
                         sess=train_sess,
-                        save_path=self.hparams.MODEL_DIR + "epoch_" + str(epoch),
+                        save_path = save_path_str,
                     )
 
             eval_start = time.time()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

existing code, in base_model.py, under the fit function -
-----------------------------------------------------------

if self.hparams.save_model:

                if epoch % self.hparams.save_epoch == 0:
                    checkpoint_path = self.saver.save(
                        sess=train_sess,
                        save_path= self.hparams.MODEL_DIR + "epoch_" + str(epoch),
                    )

Modified code:

if self.hparams.save_model:
                if epoch % self.hparams.save_epoch == 0:
                    save_path_str = self.hparams.MODEL_DIR + "/" + "epoch_" + str(epoch)
                    checkpoint_path = self.saver.save(
                        sess=train_sess,
                        save_path= save_path_str,
                    )

 -> Added a new variable, "save_path_str", that captures the save_path & file name as a string. save_path_str is then passed on to the save_path variable in the save() function.

<!--- Why is this change required? What problem does it solve? -->

When running the xDeepFM script, the model was not getting saved to the ./outputs directory in the Azure Machine Learning Service. This was due to the way in which the string concatenation for save directory was set up - the model directory & the file names were concatenated without a "/" in between them. As a result, Azure Machine Learning Service was not able to save models.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->

This is a fix for Issue #970 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.