### PR TITLE
Fix reference to the formula containing T (time decay)

### DIFF
--- a/notebooks/02_model/sar_deep_dive.ipynb
+++ b/notebooks/02_model/sar_deep_dive.ipynb
@@ -325,7 +325,7 @@
     "|Parameter|Value|Description|\n",
     "|---------|---------|-------------|\n",
     "|`similarity_type`|`jaccard`|Method used to calculate item similarity.|\n",
-    "|`time_decay_coefficient`|30|Period in days (term of $T$ shown in the formula of Section 2.2.2)|\n",
+    "|`time_decay_coefficient`|30|Period in days (term of $T$ shown in the formula of Section 1.2)|\n",
     "|`time_now`|`None`|Time decay reference.|\n",
     "|`timedecay_formula`|`True`|Whether time decay formula is used.|"
    ]


### PR DESCRIPTION
The section is labelled manually, so I believe the label changed but this reference did not.

### Description
This is only a text change.
It helps people understand the setting and its relationship to the main formula better.
