### PR TITLE
Avoid pandas >1

### DIFF
--- a/scripts/generate_conda_file.py
+++ b/scripts/generate_conda_file.py
@@ -35,6 +35,7 @@ $ python -m ipykernel install --user --name {conda_env} --display-name "Python (
 CHANNELS = ["defaults", "conda-forge", "pytorch", "fastai"]
 
 CONDA_BASE = {
+    "python": "python==3.6.10",
     "bottleneck": "bottleneck==1.2.1",
     "dask": "dask>=0.17.1",
     "fastparquet": "fastparquet>=0.1.6",
@@ -43,9 +44,8 @@ CONDA_BASE = {
     "matplotlib": "matplotlib>=2.2.2",
     "mock": "mock==2.0.0",
     "numpy": "numpy>=1.13.3",
-    "pandas": "pandas>=0.23.4",
+    "pandas": "pandas>=0.23.4,<1.0.0",
     "pip": "pip>=19.0.3",
-    "python": "python==3.6.8",
     "pytest": "pytest>=3.6.4",
     "pytorch": "pytorch-cpu>=1.0.0",
     "seaborn": "seaborn>=0.8.1",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
With great sorrow and unceasing anguish in my heart, I submit this PR to avoid our libraries to use pandas >1. This should fix #1045, #1046 and #1047. 

If we can't trust in pandas, where is this world going?

<img src="https://media.giphy.com/media/3o7abspvhYHpMnHSuc/giphy.gif" />

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/microsoft/recommenders/issues/1047
https://github.com/microsoft/recommenders/issues/1046
https://github.com/microsoft/recommenders/issues/1045

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging` and not `master`.
