### PR TITLE
Fix NNI Test Case

### DIFF
--- a/reco_utils/tuning/nni/ncf_utils.py
+++ b/reco_utils/tuning/nni/ncf_utils.py
@@ -5,17 +5,17 @@ import pandas as pd
 
 
 def compute_test_results(model, train, test, rating_metrics, ranking_metrics):
-	"""Compute the test results using a trained NCF model.
+    """Compute the test results using a trained NCF model.
     
     Args:
-    	model (obj): TF model.
+        model (obj): TF model.
         train (pd.DataFrame): Train set.
         test (pd.DataFrame): Test set.
         rating_metrics (list): List of rating metrics.
         ranking_metrics (list): List of ranking metrics.
         
     Returns:
-    	dict: Test results. 
+        dict: Test results. 
     
     """
     test_results = {}
@@ -51,13 +51,13 @@ def compute_test_results(model, train, test, rating_metrics, ranking_metrics):
   
   
 def combine_metrics_dicts(*metrics):
-	"""Combine metrics from dicts.
+    """Combine metrics from dicts.
     
     Args:
-    	metrics (dict): Metrics
+        metrics (dict): Metrics
         
     Returns:
-    	pd.DataFrame: Dataframe with metrics combined.    
+        pd.DataFrame: Dataframe with metrics combined.    
     """
     df = pd.DataFrame(metrics[0], index=[0])
     for metric in metrics[1:]:

--- a/tests/unit/test_nni_utils.py
+++ b/tests/unit/test_nni_utils.py
@@ -166,13 +166,14 @@ def test_check_metrics_written_timeout():
 @pytest.mark.skipif(sys.platform == "win32", reason="nni not installable on windows")
 def test_get_trials():
     with TemporaryDirectory() as tmp_dir1, TemporaryDirectory() as tmp_dir2:
+        
         mock_trials = [
             {
-                "finalMetricData": [{"data": '{"rmse":0.8,"default":0.3}'}],
+                "finalMetricData":[{"data":"\"{\\\"rmse\\\": 0.8, \\\"default\\\": 0.3}\""}],
                 "logPath": "file://localhost:{}".format(tmp_dir1),
             },
             {
-                "finalMetricData": [{"data": '{"rmse":0.9,"default":0.2}'}],
+                "finalMetricData":[{"data":"\"{\\\"rmse\\\": 0.9, \\\"default\\\": 0.2}\""}],
                 "logPath": "file://localhost:{}".format(tmp_dir2),
             },
         ]


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Fixed the NNI test case. 
The NNI server returns a json object with a number of escaped characters such as
```json
"finalMetricData":[{"timestamp":1593483585712,"trialJobId":"yr1Mf","parameterId":"0","type":"FINAL","sequence":0,"data":"\"{\\\"rmse\\\": 3.2157589095060417, \\\"default\\\": 0.10604453870625664, \\\"ndcg_at_k\\\": 0.12934821010667147}\""}]
```
The data in `mock_trials` for the test case `test_get_trials` under `tests/unit/test_nni_utils.py` is now formatted to match NNI.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1125 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging` and not `master`.
