### PR TITLE
Add cudatoolkit 10.0 for tf gpu

### DIFF
--- a/tests/unit/test_gpu_utils.py
+++ b/tests/unit/test_gpu_utils.py
@@ -3,6 +3,9 @@
 
 import sys
 import pytest
+import tensorflow as tf
+import torch
+
 from reco_utils.common.gpu_utils import (
     get_cuda_version,
     get_cudnn_version,
@@ -37,3 +40,14 @@ def test_get_cuda_version():
 @pytest.mark.gpu
 def test_get_cudnn_version():
     assert get_cudnn_version() > "7.0.0"
+
+    
+@pytest.mark.gpu
+def test_tensorflow_gpu():
+    assert tf.test.is_gpu_available()
+
+
+@pytest.mark.gpu
+def test_pytorch_gpu():
+    assert torch.cuda.is_available()
+

--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -67,6 +67,7 @@ CONDA_GPU = {
     "fastai": "fastai==1.0.46",
     "numba": "numba>=0.38.1",
     "pytorch": "pytorch>=1.0.0",
+    "cudatoolkit": "cudatoolkit=10.0",
 }
 
 PIP_BASE = {


### PR DESCRIPTION
### Description
Specify cudatoolkit to 10.0 which is compatible to tensorflow 1.15 so that both torch and tensorflow can use gpu.

We may want to add gpu-env test that does:
```
assert tf.test.is_gpu_available()
assert torch.cuda.is_available()
```

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging` and not `master`.
