### PR TITLE
Avoid SyntaxWarning on Python >= 3.8

### DIFF
--- a/contrib/sarplus/python/tests/test_pyspark_sar.py
+++ b/contrib/sarplus/python/tests/test_pyspark_sar.py
@@ -331,7 +331,7 @@ def test_sar_item_similarity(
         .reset_index(drop=True)
     )
 
-    if similarity_type is "cooccurrence":
+    if similarity_type == "cooccurrence":
         assert (item_similarity_ref == item_similarity).all().all()
     else:
         assert (

--- a/tests/unit/test_sar_singlenode.py
+++ b/tests/unit/test_sar_singlenode.py
@@ -116,7 +116,7 @@ def test_sar_item_similarity(
         sar_settings["FILE_DIR"] + "sim_" + file + str(threshold) + ".csv"
     )
 
-    if similarity_type is "cooccurrence":
+    if similarity_type == "cooccurrence":
         test_item_similarity = _rearrange_to_test(
             model.item_similarity.todense(),
             row_ids,


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "cooccurrence" is "cooccurrence"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging` and not `master`.
