### PR TITLE
Added Java v8 reference and install code for MacOS

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -53,19 +53,10 @@ which you can use to create the target environment using the Python version 3.6 
 
 **NOTE** the `xlearn` package has dependency on `cmake`. If one uses the `xlearn` related notebooks or scripts, make sure `cmake` is installed in the system. The easiest way to install on Linux is with apt-get: `sudo apt-get install -y build-essential cmake`. Detailed instructions for installing `cmake` from source can be found [here](https://cmake.org/install/).
 
-Assuming the repo is cloned as `Recommenders` in the local system, to install **a default (Python CPU) environment**:
+**NOTE** PySpark v2.4.x requires Java version 8. 
 
-    cd Recommenders
-    python tools/generate_conda_file.py
-    conda env create -f reco_base.yaml
-
-You can specify the environment name as well with the flag `-n`.
-
-<details>
-<summary><strong><em>Java version for PySpark</em></strong></summary>
-
-**Note.** By default we use pyspark v2.4.3. It doesn't work on Java versions >8.
-
+<details> 
+<summary><strong><em>Install Java 8 on MacOS</em></strong></summary>
 To install Java 8 on MacOS using [asdf](https://github.com/halcyon/asdf-java):
 
     brew install asdf
@@ -75,6 +66,14 @@ To install Java 8 on MacOS using [asdf](https://github.com/halcyon/asdf-java):
     . ~/.asdf/plugins/java/set-java-home.zsh
 
 </details>
+
+Assuming the repo is cloned as `Recommenders` in the local system, to install **a default (Python CPU) environment**:
+
+    cd Recommenders
+    python tools/generate_conda_file.py
+    conda env create -f reco_base.yaml
+
+You can specify the environment name as well with the flag `-n`.
 
 Click on the following menus to see how to install Python GPU and PySpark environments:
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -61,6 +61,21 @@ Assuming the repo is cloned as `Recommenders` in the local system, to install **
 
 You can specify the environment name as well with the flag `-n`.
 
+<details>
+<summary><strong><em>Java version for PySpark</em></strong></summary>
+
+**Note.** By default we use pyspark v2.4.3. It doesn't work on Java versions >8.
+
+To install Java 8 on MacOS using [asdf](https://github.com/halcyon/asdf-java):
+
+    brew install asdf
+    asdf plugin add Java
+    asdf install java adoptopenjdk-8.0.265+1
+    asdf global java adoptopenjdk-8.0.265+1
+    . ~/.asdf/plugins/java/set-java-home.zsh
+
+</details>
+
 Click on the following menus to see how to install Python GPU and PySpark environments:
 
 <details>


### PR DESCRIPTION
### Description
Added info about Java v8 needed for PySpark to work. Added MacOS install instructions.

### Related Issues
https://github.com/microsoft/recommenders/issues/1207 


### Checklist:
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging` and not `master`.
