### PR TITLE
pin lightfm version to 1.15

### DIFF
--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -41,7 +41,7 @@ CONDA_BASE = {
     "fastparquet": "fastparquet>=0.1.6",
     "ipykernel": "ipykernel>=4.6.1",
     "jupyter": "jupyter>=1.0.0",
-    "lightfm": "lightfm>=1.15",
+    "lightfm": "lightfm==1.15",
     "matplotlib": "matplotlib>=2.2.2",
     "mock": "mock==2.0.0",
     "nltk": "nltk>=3.4",


### PR DESCRIPTION
lightfm 1.16 will cause tests to fail (illegal instruction).

### Description
<!--- Describe your changes in detail -->

Pinned lightfm version to 1.15.

<!--- Why is this change required? What problem does it solve? -->



### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->

lightfm 1.16 will cause the following: 

pytest tests/unit -m "not notebooks and not spark and gpu" --durations 0
================================================= test session starts ==================================================platform linux -- Python 3.6.11, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/azureuser/src/recommenders, configfile: pytest.ini
collecting 9 items / 4 errors / 5 selected                                                                             Fatal Python error: Illegal instruction

Current thread 0x00007f1057197740 (most recent call first):
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 929 in exec_module
  File "<frozen importlib._bootstrap>", line 665 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 955 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 971 in _find_and_load
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/lightfm/_lightfm_fast.py", line 3 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 678 in exec_module
  File "<frozen importlib._bootstrap>", line 665 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 955 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 971 in _find_and_load
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/lightfm/lightfm.py", line 8 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 678 in exec_module
  File "<frozen importlib._bootstrap>", line 665 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 955 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 971 in _find_and_load
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/lightfm/__init__.py", line 4 in <module>
  File "<frozen importlib._bootstrap>", line 219 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 678 in exec_module
  File "<frozen importlib._bootstrap>", line 665 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 955 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 971 in _find_and_load
  File "/home/azureuser/src/recommenders/tests/unit/test_lightfm_utils.py", line 8 in <module>
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/assertion/rewrite.py", line 170 in exec_module
  File "<frozen importlib._bootstrap>", line 665 in _load_unlocked
  File "<frozen importlib._bootstrap>", line 955 in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 971 in _find_and_load
  File "<frozen importlib._bootstrap>", line 994 in _gcd_import
 File "/anaconda/envs/rf3/lib/python3.6/importlib/__init__.py", line 126 in import_module
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/pathlib.py", line 531 in import_path
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/python.py", line 578 in _importtestmodule
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/python.py", line 500 in _getobj
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/python.py", line 291 in obj
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/python.py", line 516 in _inject_setup_module_fixture
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/python.py", line 503 in collect
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/runner.py", line 341 in <lambda>
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/runner.py", line 311 in from_call
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/runner.py", line 341 in pytest_make_collect_report
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/runner.py", line 458 in collect_one_node
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/main.py", line 808 in genitems
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/main.py", line 634 in perform_collect
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/main.py", line 333 in pytest_collection
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/main.py", line 322 in _main
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/main.py", line 269 in wrap_session
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/main.py", line 316 in pytest_cmdline_main
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/config/__init__.py", line 163 in main
  File "/anaconda/envs/rf3/lib/python3.6/site-packages/_pytest/config/__init__.py", line 185 in console_main
  File "/anaconda/envs/rf3/bin/pytest", line 11 in <module>
Illegal instruction (core dumped)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging` and not `master`.
