### PR TITLE
Change package name to underscore

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -351,4 +351,4 @@ First make sure that the tag that you want to add, e.g. `0.6.0`, is added in [re
 generates a wheel and a tar.gz which are uploaded to a [GitHub draft release](https://github.com/microsoft/recommenders/releases).
 1. Fill up the draft release with all the recent changes in the code.
 1. Download the wheel and tar.gz locally, these files shouldn't have any bug, since they passed all the tests.
-1. Publish the wheel and tar.gz to pypi: `twine upload ms-recommenders*`
+1. Publish the wheel and tar.gz to pypi: `twine upload ms_recommenders*`

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ HASH = environ.get("HASH", None)
 if HASH is not None:
     version += ".post" + str(int(time.time()))
 
-name = environ.get("LIBRARY_NAME", "ms-recommenders")
+name = environ.get("LIBRARY_NAME", "ms_recommenders")
 
 install_requires = [
     "numpy>=1.14",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Change package name to underscore so both wheel and tar.gz has the same pattern:

```
ms_recommenders-0.6.0.post1623931532-py3-none-manylinux1_x86_64.whl  
ms_recommenders-0.6.0.post1623931532.tar.gz
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
