### PR TITLE
Add gpu build

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -3,6 +3,3 @@
 # https://docs.codecov.com/docs/pull-request-comments#section-behavior
 comment:
   behavior: new
-  layout: "sunburst, diff, files"
-  require_head: no
-  require_base: no

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -5,6 +5,9 @@
 name: pr-gate
 
 on:
+  pull_request:
+    branches: [ staging, main ]
+  # development triggers can be removed afterwards.
   push:
     branches: [ laserprec/gpu-ci, laserprec/ghaction-sandbox* ]
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -6,7 +6,7 @@ name: pr-gate
 
 on:
   push:
-    branches: [ laserprec/ghaction-ci, laserprec/ghaction-sandbox* ]
+    branches: [ laserprec/gpu-ci, laserprec/ghaction-sandbox* ]
 
 # This file defines following CI workflow:
 #
@@ -20,7 +20,7 @@ on:
 #               │ └─────────┘ │
 #               │ ┌─────────┐ │
 #               └─►  build* ├─┘
-#                 │  (gpu)  │   <-- TODO: Coming Soon
+#                 │  (gpu)  │
 #                 └─────────┘
 #                    ....
 # *each runs in PARALLEL the different combinations
@@ -136,11 +136,46 @@ jobs:
         path: .coverage*
 
 ###############################################
+################# GPU-BUILD #################
+###############################################
+  build-gpu:
+    runs-on: [self-hosted, Linux, gpu] # this is a union of labels to select specific self-hosted machine
+    needs: static-analysis
+    strategy:
+      matrix:
+        python: [3.6]
+        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        test-kind: ['unit'] 
+        # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
+        test-marker: ['gpu and notebooks and not spark', 'gpu and not notebooks and not spark']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    ################# Run Python tests #################
+    - name: Use Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Run ${{ matrix.test-kind }} tests ('${{ matrix.test-marker }}')
+      uses: ./.github/workflows/actions/run-tests
+      with:
+        test-kind: ${{ matrix.test-kind }}
+        test-marker: ${{ matrix.test-marker }}
+      
+    - name: Upload Code Coverage
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-cov
+        path: .coverage*
+
+###############################################
 ############ TEST COVERAGE SUMMARY ############
 ###############################################
   collect-code-cov:
     runs-on: ubuntu-latest
-    needs: [build-cpu, build-spark]
+    needs: [build-cpu, build-spark, build-gpu]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
### Description
To improve developer experience working with this repo, we will begin migrating our DevOps pipelines into Github Action, along with consolidating documentations and leveraging popular DevOps tools like tox and flake8. This will be a sequence of updates to our DevOps infrastructures:

1. ~~Propose and draft the CI pipeline in Github Action~~
2. Setup self-hosted machines to run our GPU workloads **<---- (Current PR)**
3. Run tests on the appropriate dependency subsets
4. Create feature parity with the existing CI pipelines (pr-gates & nightly-build)
5. Optimize build time for unit tests
6. Enforce flake8 (coding style checks) on the build and clean up coding styles to pass flake8 checks
7. Deprecate CI pipelines in ADO and switch to Github Actions

#### In THIS PR
we have the following changes:
- Add a GPU build step to PR-gate

![image](https://user-images.githubusercontent.com/19534002/129749562-c478cfa6-2ba8-4804-896f-d473a9a2d537.png)


### Related Issues
- #1498 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions. (N/A)
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
