### PR TITLE
Add nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ on:
   push:
     # because we can't schedule run for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
-    branches: [staging]
+    branches: [staging, laserprec/nightly-ci]
 
   # enable manual trigger
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,31 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # ---------------------------------------------------------
+
+# NOTE:
+# This file defines following CI workflow:
+#  ┌──────────┐   ┌─────────┐   ┌────────┐
+#  │  static  ├─┬─►  build* ├─┬─►  test  │
+#  │ analysis │ │ │  (cpu)  │ │ │ report │
+#  └──────────┘ │ └─────────┘ │ └────────┘         
+#               │ ┌─────────┐ │
+#               ├─►  build* ├─┤
+#               │ │ (spark) │ │
+#               │ └─────────┘ │
+#               │ ┌─────────┐ │
+#               └─►  build* ├─┘
+#                 │  (gpu)  │
+#                 └─────────┘
+#                    ....
+# *each runs in PARALLEL the different combinations
+#  of python version, OS, test subsets, etc
+#
+# There are 3 compute environments our library is supporting: CPU, GPU and Spark
+# This pipeline's goal is to ensure we run and pass our tests in these supported compute
+# For all of the jobs in GPU build, we are using self-host VMs to run them.
+# For the rest of the jobs, with the exception of integration tests (#1507), we will use default agents provided by GitHub 
+#
+# ASCII chart created via https://asciiflow.com/
 name: nightly
 
 on:
@@ -28,26 +53,6 @@ on:
         description: 'Test scenario tags'
         default: 'Anything to describe this manual run (optional)'
     
-
-# This file defines following CI workflow:
-#
-#  ┌──────────┐   ┌─────────┐   ┌────────┐
-#  │  static  ├─┬─►  build* ├─┬─►  test  │
-#  │ analysis │ │ │  (cpu)  │ │ │ report │
-#  └──────────┘ │ └─────────┘ │ └────────┘         
-#               │ ┌─────────┐ │
-#               ├─►  build* ├─┤
-#               │ │ (spark) │ │
-#               │ └─────────┘ │
-#               │ ┌─────────┐ │
-#               └─►  build* ├─┘
-#                 │  (gpu)  │
-#                 └─────────┘
-#                    ....
-# *each runs in PARALLEL the different combinations
-#  of python version, OS, test subsets, etc
-#
-#  ASCII chart created via https://asciiflow.com/
 
 jobs:
 ###############################################

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,210 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# ---------------------------------------------------------
+name: nightly
+
+on:
+  #            ┌───────────── minute (0 - 59)
+  #            │ ┌───────────── hour (0 - 23)
+  #            │ │ ┌───────────── day of the month (1 - 31)
+  #            │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #            │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)                                  
+  #            │ │ │ │ │
+  #            │ │ │ │ │
+  # schedule: "0 0 * * *"  # basically running everyday at 12AM
+  #   branches: [ staging, main ]
+
+  # development triggers, can be removed afterwards.
+  push:
+    branches: [ laserprec/nightly-ci ]
+
+# This file defines following CI workflow:
+#
+#  ┌──────────┐   ┌─────────┐   ┌────────┐
+#  │  static  ├─┬─►  build* ├─┬─►  test  │
+#  │ analysis │ │ │  (cpu)  │ │ │ report │
+#  └──────────┘ │ └─────────┘ │ └────────┘         
+#               │ ┌─────────┐ │
+#               ├─►  build* ├─┤
+#               │ │ (spark) │ │
+#               │ └─────────┘ │
+#               │ ┌─────────┐ │
+#               └─►  build* ├─┘
+#                 │  (gpu)  │
+#                 └─────────┘
+#                    ....
+# *each runs in PARALLEL the different combinations
+#  of python version, OS, test subsets, etc
+#
+#  ASCII chart created via https://asciiflow.com/
+
+jobs:
+###############################################
+############### STATIC-ANALYSIS ###############
+###############################################
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    
+    - name: Install dependencies (tox)
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install tox
+
+    - name: Run flake8
+      # TODO: re-enable this flake8 block (turned off to get a draft of the pipeline infrastructure)
+      continue-on-error: true
+      run: |
+       tox -e flake8
+
+###############################################
+################## CPU-BUILD ##################
+###############################################
+  build-cpu:
+    runs-on: ${{ matrix.os }}
+    needs: static-analysis
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: [3.6]
+        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        test-kind: ['unit', 'smoke', 'integration'] 
+        # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
+        test-marker: ['not spark and not gpu']
+
+    steps:
+    - uses: actions/checkout@v2
+    ################# Run Python tests #################
+    - name: Use Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    # There are little documentation on how to call **local** actions
+    # https://docs.github.com/en/actions/creating-actions/about-actions#choosing-a-location-for-your-action
+    # but there is some working insights from this discussion:
+    # https://github.community/t/path-to-action-in-the-same-repository-as-workflow/16952/2
+    - name: Run ${{ matrix.test-kind }} tests ('${{ matrix.test-marker }}')
+      uses: ./.github/workflows/actions/run-tests
+      with:
+        test-kind: ${{ matrix.test-kind }}
+        test-marker: ${{ matrix.test-marker }}
+    # Currently GitHub workflow cannot call an action from another action
+    # https://github.community/t/call-an-action-from-another-action/17524
+    # Else this shared step can also be move to the local action: .github/workflows/actions/run-tests
+    - name: Upload Code Coverage
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-cov
+        path: .coverage*
+
+###############################################
+################# SPARK-BUILD #################
+###############################################
+  build-spark:
+    runs-on: ${{ matrix.os }}
+    needs: static-analysis
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [8]
+        python: [3.6]
+        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        test-kind: ['unit', 'smoke', 'integration'] 
+        # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
+        test-marker: ['spark and not gpu']
+
+    steps:
+    - uses: actions/checkout@v2
+    ################# Install spark dependencies (java) #################
+    - name: Setup Java JDK
+      uses: actions/setup-java@v2.1.0
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'adopt'
+    
+    ################# Run Python tests #################
+    - name: Use Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Run ${{ matrix.test-kind }} tests ('${{ matrix.test-marker }}')
+      uses: ./.github/workflows/actions/run-tests
+      with:
+        test-kind: ${{ matrix.test-kind }}
+        test-marker: ${{ matrix.test-marker }}
+      
+    - name: Upload Code Coverage
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-cov
+        path: .coverage*
+
+###############################################
+################# GPU-BUILD #################
+###############################################
+  build-gpu:
+    runs-on: [self-hosted, Linux, gpu] # this is a union of labels to select specific self-hosted machine
+    needs: static-analysis
+    strategy:
+      matrix:
+        python: [3.6]
+        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        test-kind: ['unit', 'smoke', 'integration'] 
+        # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
+        test-marker: ['gpu and not spark']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    ################# Run Python tests #################
+    - name: Use Python ${{ matrix.python }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Run ${{ matrix.test-kind }} tests ('${{ matrix.test-marker }}')
+      uses: ./.github/workflows/actions/run-tests
+      with:
+        test-kind: ${{ matrix.test-kind }}
+        test-marker: ${{ matrix.test-marker }}
+      
+    - name: Upload Code Coverage
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-cov
+        path: .coverage*
+
+###############################################
+############ TEST COVERAGE SUMMARY ############
+###############################################
+  collect-code-cov:
+    runs-on: ubuntu-latest
+    needs: [build-cpu, build-spark, build-gpu]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: '3.6'
+
+      - name: Download coverage reports from all previous jobs
+        uses: actions/download-artifact@v2
+        with:
+          name: code-cov
+
+      - name: Merge coverage reports
+        uses: ./.github/workflows/actions/merge-cov
+          
+      - name: Upload code coverage report to CodeCov
+        uses: codecov/codecov-action@v2.0.2
+        with:
+          fail_ci_if_error: true
+          # comes from the last 'Merge coverage reports' step
+          files: ./coverage.xml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,20 +5,20 @@
 name: nightly
 
 on:
-  #            ┌───────────── minute (0 - 59)
-  #            │ ┌───────────── hour (0 - 23)
-  #            │ │ ┌───────────── day of the month (1 - 31)
-  #            │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  #            │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)                                  
-  #            │ │ │ │ │
-  #            │ │ │ │ │
-  schedule:
-    - cron: '0 0 * * *'  # basically running everyday at 12AM\
+  #          ┌───────────── minute (0 - 59)
+  #          │ ┌───────────── hour (0 - 23)
+  #          │ │ ┌───────────── day of the month (1 - 31)
+  #          │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #          │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)                                  
+  #          │ │ │ │ │
+  #          │ │ │ │ │
+  schedule: 
+    - cron: '0 0 * * *'  # basically running everyday at 12AM
     # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
   
   push:
     branches:
-      # Before we can't schedule run for non-main branches,
+      # Because we can't schedule run for non-main branches,
       # to ensure we are running the build on the staging branch, we can add push policy for it
       - staging
       # Development triggers, can be removed afterwards
@@ -82,6 +82,10 @@ jobs:
         test-kind: ['unit', 'smoke', 'integration'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['not spark and not gpu']
+        include:
+          # Integration tests needs a more powermachine with more memory. GitHub-hosted agents only have 7GB memory.
+          - os: self-hosted
+            test-kind: 'integration'
 
     steps:
     - uses: actions/checkout@v2
@@ -123,6 +127,11 @@ jobs:
         test-kind: ['unit', 'smoke', 'integration'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['spark and not gpu']
+        include:
+          # Integration tests needs a more powermachine with more memory. GitHub-hosted agents only have 7GB memory.
+          - os: self-hosted
+            test-kind: 'integration'
+        
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ on:
     # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
   
   push:
-    # because we can't schedule run for non-main branches,
+    # because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging, laserprec/nightly-ci]
 
@@ -139,9 +139,10 @@ jobs:
           # Integration tests need a powerful machine with more memory. GitHub-hosted agents only have 7GB memory.
           # TODO: Optimization/refactoring should be done to ensure that these test can run in the default CI agent (#1507)
           - os: self-hosted
+            java: 8
             python: 3.6
             test-kind: 'integration'
-            test-marker: 'not spark and not gpu'
+            test-marker: 'spark and not gpu'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -79,13 +79,15 @@ jobs:
         os: [ubuntu-latest]
         python: [3.6]
         # different kind of tests are located in tests/<unit|integration|smoke> folders
-        test-kind: ['unit', 'smoke', 'integration'] 
+        test-kind: ['unit', 'smoke']
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['not spark and not gpu']
         include:
           # Integration tests needs a more powermachine with more memory. GitHub-hosted agents only have 7GB memory.
           - os: self-hosted
+            python: 3.6
             test-kind: 'integration'
+            test-marker: 'not spark and not gpu'
 
     steps:
     - uses: actions/checkout@v2
@@ -124,13 +126,16 @@ jobs:
         java: [8]
         python: [3.6]
         # different kind of tests are located in tests/<unit|integration|smoke> folders
-        test-kind: ['unit', 'smoke', 'integration'] 
+        test-kind: ['unit', 'smoke'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['spark and not gpu']
         include:
           # Integration tests needs a more powermachine with more memory. GitHub-hosted agents only have 7GB memory.
           - os: self-hosted
+            python: 3.6
             test-kind: 'integration'
+            test-marker: 'not spark and not gpu'
+
         
 
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,12 +78,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: [3.6]
-        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit', 'smoke']
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['not spark and not gpu']
         include:
-          # Integration tests needs a more powermachine with more memory. GitHub-hosted agents only have 7GB memory.
+          # Integration tests need a powerful machine with more memory. GitHub-hosted agents only have 7GB memory.
+          # TODO: Optimization/refactoring should be done to ensure that these test can run in the default CI agent (#1507)
           - os: self-hosted
             python: 3.6
             test-kind: 'integration'
@@ -125,12 +126,13 @@ jobs:
         os: [ubuntu-latest]
         java: [8]
         python: [3.6]
-        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit', 'smoke'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['spark and not gpu']
         include:
-          # Integration tests needs a more powermachine with more memory. GitHub-hosted agents only have 7GB memory.
+          # Integration tests need a powerful machine with more memory. GitHub-hosted agents only have 7GB memory.
+          # TODO: Optimization/refactoring should be done to ensure that these test can run in the default CI agent (#1507)
           - os: self-hosted
             python: 3.6
             test-kind: 'integration'
@@ -174,7 +176,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6]
-        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit', 'smoke', 'integration'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['gpu and not spark']

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ on:
   push:
     # because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
-    branches: [staging, laserprec/nightly-ci]
+    branches: [staging]
 
   # enable manual trigger
   workflow_dispatch:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,12 +12,17 @@ on:
   #            │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)                                  
   #            │ │ │ │ │
   #            │ │ │ │ │
-  # schedule: "0 0 * * *"  # basically running everyday at 12AM
-  #   branches: [ staging, main ]
-
-  # development triggers, can be removed afterwards.
+  schedule:
+    - cron: '0 0 * * *'  # basically running everyday at 12AM\
+    # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
+  
   push:
-    branches: [ laserprec/nightly-ci ]
+    branches:
+      # Before we can't schedule run for non-main branches,
+      # to ensure we are running the build on the staging branch, we can add push policy for it
+      - staging
+      # Development triggers, can be removed afterwards
+      - laserprec/nightly-ci
 
 # This file defines following CI workflow:
 #

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,12 +17,17 @@ on:
     # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
   
   push:
-    branches:
-      # Because we can't schedule run for non-main branches,
-      # to ensure we are running the build on the staging branch, we can add push policy for it
-      - staging
-      # Development triggers, can be removed afterwards
-      - laserprec/nightly-ci
+    # because we can't schedule run for non-main branches,
+    # to ensure we are running the build on the staging branch, we can add push policy for it
+    branches: [staging]
+
+  # enable manual trigger
+  workflow_dispatch:
+    input:
+      tags:
+        description: 'Test scenario tags'
+        default: 'Anything to describe this manual run (optional)'
+    
 
 # This file defines following CI workflow:
 #
@@ -137,8 +142,6 @@ jobs:
             python: 3.6
             test-kind: 'integration'
             test-marker: 'not spark and not gpu'
-
-        
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -8,6 +8,13 @@ on:
   pull_request:
     branches: [ staging, main ]
 
+  # enable manual trigger
+  workflow_dispatch:
+    input:
+      tags:
+        description: 'Test scenario tags'
+        default: 'Anything to describe this manual run (optional)'
+
 # This file defines following CI workflow:
 #
 #  ┌──────────┐   ┌─────────┐   ┌────────┐

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -2,21 +2,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 # ---------------------------------------------------------
-name: pr-gate
 
-on:
-  pull_request:
-    branches: [ staging, main ]
-
-  # enable manual trigger
-  workflow_dispatch:
-    input:
-      tags:
-        description: 'Test scenario tags'
-        default: 'Anything to describe this manual run (optional)'
-
+# NOTE:
 # This file defines following CI workflow:
-#
 #  ┌──────────┐   ┌─────────┐   ┌────────┐
 #  │  static  ├─┬─►  build* ├─┬─►  test  │
 #  │ analysis │ │ │  (cpu)  │ │ │ report │
@@ -33,7 +21,24 @@ on:
 # *each runs in PARALLEL the different combinations
 #  of python version, OS, test subsets, etc
 #
-#  ASCII chart created via https://asciiflow.com/
+# There are 3 compute environments our library is supporting: CPU, GPU and Spark
+# This pipeline's goal is to ensure we run and pass our tests in these supported compute envs
+# For all of the jobs in GPU build, we are using self-host VMs to run them.
+#
+# ASCII chart created via https://asciiflow.com/
+name: pr-gate
+
+on:
+  pull_request:
+    branches: [ staging, main ]
+
+  # enable manual trigger
+  workflow_dispatch:
+    input:
+      tags:
+        description: 'Test scenario tags'
+        default: 'Anything to describe this manual run (optional)'
+
 
 jobs:
 ###############################################

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -7,9 +7,6 @@ name: pr-gate
 on:
   pull_request:
     branches: [ staging, main ]
-  # development triggers can be removed afterwards.
-  push:
-    branches: [ laserprec/gpu-ci, laserprec/ghaction-sandbox* ]
 
 # This file defines following CI workflow:
 #

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: [3.6]
-        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['not gpu and not spark and not notebooks', 'notebooks and not gpu and not spark']
@@ -103,7 +103,7 @@ jobs:
         os: [ubuntu-latest]
         java: [8]
         python: [3.6]
-        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['notebooks and spark and not gpu', 'spark and not notebooks and not gpu']
@@ -144,7 +144,7 @@ jobs:
     strategy:
       matrix:
         python: [3.6]
-        # different kind of tests are located in tests/<unit|integration|smoke> folders
+        # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
         test-marker: ['gpu and notebooks and not spark', 'gpu and not notebooks and not spark']


### PR DESCRIPTION
### Description
To improve developer experience working with this repo, we will begin migrating our DevOps pipelines into Github Action, leveraging popular DevOps tools like `tox` and `flake8`. This will be a sequence of updates to our DevOps infrastructures:

1. ~~Propose and draft the CI pipeline in Github Action~~
2. ~~Setup self-hosted machines to run our GPU workloads~~
3. Create feature parity with the existing CI pipelines (pr-gates & nightly-build)  **<---- (Current PR)**
4. Run tests on the appropriate dependency subsets
5. Optimize build time for unit tests
6. Enforce flake8 (coding style checks) on the build and clean up coding styles to pass flake8 checks
7. Deprecate CI pipelines in ADO and switch to Github Actions

#### In this PR:

Add a nightly build pipeline that runs the full test suites: unit, integration and smoke tests:
![image](https://user-images.githubusercontent.com/19534002/130111571-7948bd8d-edae-4777-9935-78f82f83425a.png)


### Related Issues
#1498 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
