### PR TITLE
Move scikit-surprise and pymanopt from setup.py 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,5 @@
 # What's New
 
-## Update December 20, 2021
-
-We have a new release [Recommenders 1.0.0](https://github.com/microsoft/recommenders/releases/tag/1.0.0)! The codebase has now migrated to TensorFlow versions 2.6 / 2.7 and to Spark version 3. In addition, there are a few changes in the dependencies and extras installed by `pip` (see [this guide](recommenders/README.md#optional-dependencies)). We have also made improvements in the code and the CI / CD pipelines.
 
 ## Update September 27, 2021
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,17 @@
 
 [![Documentation Status](https://readthedocs.org/projects/microsoft-recommenders/badge/?version=latest)](https://microsoft-recommenders.readthedocs.io/en/latest/?badge=latest)
 
-## What's New (December 20, 2021)
+## What's New (September 27, 2021)
 
-We have a new release [Recommenders 1.0.0](https://github.com/microsoft/recommenders/releases/tag/1.0.0)! The codebase has now migrated to TensorFlow versions 2.6 / 2.7 and to Spark version 3. In addition, there are a few changes in the dependencies and extras installed by `pip` (see [this guide](recommenders/README.md#optional-dependencies)). We have also made improvements in the code and the CI / CD pipelines.
+We have a new release [Recommenders 0.7.0](https://github.com/microsoft/recommenders/releases/tag/0.7.0)!
 
-Starting with release 0.6.0, Recommenders has been available on PyPI and can be installed using pip! 
+In this, we have changed the names of the folders which contain the source code, so that they are more informative. This implies that you will need to change any import statements that reference the recommenders package. Specifically, the folder `reco_utils` has been renamed to `recommenders` and its subfolders have been renamed according to [issue 1390](https://github.com/microsoft/recommenders/issues/1390).  
 
-Here you can find the PyPi page: https://pypi.org/project/recommenders/
+The recommenders package now supports three types of environments: [venv](https://docs.python.org/3/library/venv.html), [virtualenv](https://virtualenv.pypa.io/en/latest/index.html#) and [conda](https://docs.conda.io/projects/conda/en/latest/glossary.html?highlight=environment#conda-environment) with Python versions 3.6 and 3.7.
 
-Here you can find the package documentation: https://microsoft-recommenders.readthedocs.io/en/latest/
+We have also added new evaluation metrics: _novelty, serendipity, diversity and coverage_ (see the [evalution notebooks](examples/03_evaluate/README.md)).
+
+Code coverage reports are now generated for every PR, using [Codecov](https://about.codecov.io/).
 
 
 ## Introduction

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@ To setup the documentation, first you need to install the dependencies of the fu
     conda activate reco_full
 
     pip install numpy cython
-    pip install --no-binary scikit-surprise .[all,experimental]
+    pip install --no-binary scikit-surprise "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz"
+    pip install "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip"
     pip install sphinx_rtd_theme
 
 

--- a/recommenders/README.md
+++ b/recommenders/README.md
@@ -35,7 +35,7 @@ By default `recommenders` does not install all dependencies used throughout the 
 - experimental: current experimental dependencies that are being evaluated (e.g. libraries that require advanced build requirements or might conflict with libraries from other options)
 - nni: dependencies for NNI tuning framework.
 
-Note that, currently, xLearn, Surprise and Vowpal Wabbit are in the experimental group.
+Note that, currently, xLearn and Vowpal Wabbit are in the experimental group.
 
 These groups can be installed alone or in combination:
 ```bash
@@ -64,9 +64,15 @@ When installing with GPU support you will need to point to the PyTorch index to 
 
 We are currently evaluating inclusion of the following dependencies:
 
- - scikit-surprise: due to incompatibilities with `numpy <= 1.19`, proper installation of Surprise requires `pip install numpy cython` and `pip install --no-binary scikit-surprise recommenders[experimental]`
  - vowpalwabbit: current examples show how to use vowpal wabbit after it has been installed on the command line; using the [PyPI package](https://pypi.org/project/vowpalwabbit/) with the scikit-learn interface will facilitate easier integration into python environments
  - xlearn: on some platforms, xLearn requires pre-installation of cmake.
+
+## Other dependencies
+
+Some dependencies are not available via the recommenders PyPI package, but can be installed in the following ways: 
+ - scikit-surprise: due to incompatibilities with `numpy <= 1.19`, proper installation of Surprise requires `pip install numpy cython` and `pip install --no-binary scikit-surprise "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz"`
+ - pymanopt: this dependency is required for the RLRMC and GeoIMC algorithms; a version of this code compatible with TensorFlow 2 can be
+ installed with `pip install "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip"`. 
 
 ## NNI dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,6 @@ install_requires = [
     "memory_profiler>=0.54.0,<1",
     "nltk>=3.4,<4",
     "pydocumentdb>=2.3.3<3",  # TODO: replace with azure-cosmos
-    # Temporary fix for pymanopt, only this commit works with TF2
-    "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip",
     "seaborn>=0.8.1,<1",
     "transformers>=2.5.0,<5",
     "bottleneck>=1.2.1,<2",
@@ -93,9 +91,6 @@ extras_require["all"] = list(set(sum([*extras_require.values()], [])))
 extras_require["experimental"] = [
     # xlearn requires cmake to be pre-installed
     "xlearn==0.40a1",
-    # Surprise needs to be built from source because of the numpy <= 1.19 incompatibility
-    # Requires pip to be run with the --no-binary option
-    "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz",
     # VW C++ binary needs to be installed manually for some code to work
     "vowpalwabbit>=8.9.0,<9",
 ]
@@ -104,6 +99,12 @@ extras_require["nni"] = [
     "nni==1.5",
 ]
 
+# The following dependencies can be installed as below, however PyPI does not allow direct URLs.
+# Surprise needs to be built from source because of the numpy <= 1.19 incompatibility
+# Requires pip to be run with the --no-binary option
+# "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz",
+# Temporary fix for pymanopt, only this commit works with TF2
+# "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip",
 
 setup(
     name="recommenders",

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_linux_cpu.yml
@@ -33,6 +33,6 @@ extends:
     timeout: 180 
     conda_env: "nightly_linux_cpu"
     conda_opts: "python=3.6"
-    pip_opts: "[examples,dev,experimental] --no-cache --no-binary scikit-surprise"
+    pip_opts: "[examples,dev,experimental] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
     pytest_markers: "not spark and not gpu"
     pytest_params: "-x"

--- a/tests/ci/azure_pipeline_test/dsvm_notebook_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_notebook_linux_cpu.yml
@@ -60,5 +60,5 @@ extends:
     task_name: "Test - Unit Notebook Linux CPU"
     conda_env: "unit_notebook_linux_cpu"
     conda_opts: "python=3.6"
-    pip_opts: "[examples,dev,experimental] --no-cache --no-binary scikit-surprise"
+    pip_opts: "[examples,dev,experimental] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
     pytest_markers: "notebooks and not spark and not gpu"

--- a/tests/ci/azure_pipeline_test/dsvm_unit_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_unit_linux_cpu.yml
@@ -60,5 +60,5 @@ extends:
     task_name: "Test - Unit Linux CPU"
     conda_env: "unit_linux_cpu"
     conda_opts: "python=3.6"
-    pip_opts: "[dev,experimental] --no-cache --no-binary scikit-surprise"
+    pip_opts: "[dev,experimental] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
     pytest_markers: "not notebooks and not spark and not gpu"

--- a/tests/unit/examples/test_notebooks_python.py
+++ b/tests/unit/examples/test_notebooks_python.py
@@ -103,6 +103,7 @@ def test_wikidata_runs(notebooks, output_notebook, kernel_name, tmp):
     )
 
 
+@pytest.mark.experimental
 @pytest.mark.notebooks
 def test_rlrmc_quickstart_runs(notebooks, output_notebook, kernel_name):
     notebook_path = notebooks["rlrmc_quickstart"]

--- a/tests/unit/recommenders/models/test_geoimc.py
+++ b/tests/unit/recommenders/models/test_geoimc.py
@@ -1,20 +1,23 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import collections
-import pytest
-import numpy as np
-from scipy.sparse import csr_matrix
+try:
+    import collections
+    import pytest
+    import numpy as np
+    from scipy.sparse import csr_matrix
 
-from recommenders.models.geoimc.geoimc_data import DataPtr
-from recommenders.models.geoimc.geoimc_predict import Inferer
-from recommenders.models.geoimc.geoimc_algorithm import IMCProblem
-from recommenders.models.geoimc.geoimc_utils import (
-    length_normalize,
-    mean_center,
-    reduce_dims,
-)
-from pymanopt.manifolds import Stiefel, SymmetricPositiveDefinite
+    from recommenders.models.geoimc.geoimc_data import DataPtr
+    from recommenders.models.geoimc.geoimc_predict import Inferer
+    from recommenders.models.geoimc.geoimc_algorithm import IMCProblem
+    from recommenders.models.geoimc.geoimc_utils import (
+        length_normalize,
+        mean_center,
+        reduce_dims,
+    )
+    from pymanopt.manifolds import Stiefel, SymmetricPositiveDefinite
+except:
+    pass    # skip if pymanopt not installed
 
 _IMC_TEST_DATA = [
     (
@@ -35,6 +38,7 @@ _IMC_TEST_DATA = [
 
 
 # `geoimc_data` tests
+@pytest.mark.experimental
 @pytest.mark.parametrize("data, entities", _IMC_TEST_DATA)
 def test_dataptr(data, entities):
     ptr = DataPtr(data, entities)
@@ -44,6 +48,7 @@ def test_dataptr(data, entities):
 
 
 # `geoimc_utils` tests
+@pytest.mark.experimental
 @pytest.mark.parametrize(
     "matrix",
     [
@@ -59,6 +64,7 @@ def test_length_normalize(matrix):
     )
 
 
+@pytest.mark.experimental
 @pytest.mark.parametrize(
     "matrix",
     [
@@ -73,12 +79,14 @@ def test_mean_center(matrix):
     )
 
 
+@pytest.mark.experimental
 def test_reduce_dims():
     matrix = np.random.rand(100, 100)
     assert reduce_dims(matrix, 50).shape[1] == 50
 
 
 # `geoimc_algorithm` tests
+@pytest.mark.experimental
 @pytest.mark.parametrize(
     "dataPtr, rank",
     [
@@ -86,6 +94,7 @@ def test_reduce_dims():
         (DataPtr(_IMC_TEST_DATA[1][0], _IMC_TEST_DATA[1][1]), 3),
     ],
 )
+@pytest.mark.experimental
 def test_imcproblem(dataPtr, rank):
 
     # Test init
@@ -110,10 +119,12 @@ def test_imcproblem(dataPtr, rank):
 
 
 # `geoimc_predict` tests
+@pytest.mark.experimental
 def test_inferer_init():
     assert Inferer(method="dot").method.__name__ == "PlainScalarProduct"
 
 
+@pytest.mark.experimental
 @pytest.mark.parametrize(
     "dataPtr",
     [

--- a/tests/unit/recommenders/models/test_surprise_utils.py
+++ b/tests/unit/recommenders/models/test_surprise_utils.py
@@ -17,7 +17,7 @@ try:
         compute_ranking_predictions,
     )
 except:
-    pass    # skip if experimental not installed
+    pass    # skip if surprise not installed
 
 TOL = 0.001
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

- Remove scikit-surprise and pymanopt from setup.py because PyPI does not allow direct URLs.
- Update documentation to show how they can be pip installed manually.
- Update their pip installation in the nightly tests. 

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->

#1597 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
