### PR TITLE
Format the getting started section to make it clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To set up on your local machine:
     1. Ensure software required for compilation and Python libraries
        is installed.
 
-       * On Linux this can be supported by adding:
+       + On Linux this can be supported by adding:
 
          ```bash
          sudo apt-get install -y build-essential libpython<version>
@@ -53,7 +53,7 @@ To set up on your local machine:
 
          where `<version>` should be `3.6` or `3.7` as appropriate.
 
-       * On Windows you will need [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+       + On Windows you will need [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
 
     2. Create a conda or virtual environment.  See the
        [setup guide](SETUP.md) for more details.

--- a/README.md
+++ b/README.md
@@ -43,40 +43,42 @@ To set up on your local machine:
 * To install core utilities, CPU-based algorithms, and dependencies:
 
     1. Ensure software required for compilation and Python libraries
-       is installed.  On Linux this can be supported by adding:
-    
-       ```bash
-       sudo apt-get install -y build-essential libpython<version>
-       ``` 
-    
-       where `<version>` should be `3.6` or `3.7` as appropriate.
-    
-       On Windows you will need [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
-      
+       is installed.
+
+       * On Linux this can be supported by adding:
+
+         ```bash
+         sudo apt-get install -y build-essential libpython<version>
+         ``` 
+
+         where `<version>` should be `3.6` or `3.7` as appropriate.
+
+       * On Windows you will need [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+
     2. Create a conda or virtual environment.  See the
        [setup guide](SETUP.md) for more details.
-    
+
     3. Within the created environment, install the package from
        [PyPI](https://pypi.org):
-    
+
        ```bash
        pip install --upgrade pip
        pip install --upgrade setuptools
        pip install recommenders[examples]
        ```
-    
+
     4. Register your (conda or virtual) environment with Jupyter:
-    
+
        ```bash
        python -m ipykernel install --user --name my_environment_name --display-name "Python (reco)"
        ```
-    
+
     5. Start the Jupyter notebook server
-    
+
        ```bash
        jupyter notebook
        ```
-    
+
     6. Run the [SAR Python CPU MovieLens](examples/00_quick_start/sar_movielens.ipynb)
        notebook under the `00_quick_start` folder.  Make sure to
        change the kernel to "Python (reco)".

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To set up on your local machine:
 * To install core utilities, CPU-based algorithms, and dependencies:
 
     1. Ensure software required for compilation and Python libraries
-       is installed. On Linux this can be supported by adding:
+       is installed.  On Linux this can be supported by adding:
     
        ```bash
        sudo apt-get install -y build-essential libpython<version>
@@ -78,8 +78,8 @@ To set up on your local machine:
        ```
     
     6. Run the [SAR Python CPU MovieLens](examples/00_quick_start/sar_movielens.ipynb)
-       notebook under the `00_quick_start` folder. Make sure to change
-       the kernel to "Python (reco)".
+       notebook under the `00_quick_start` folder.  Make sure to
+       change the kernel to "Python (reco)".
 
 * For additional options to install the package (support for GPU,
   Spark etc.) see [this guide](recommenders/README.md).

--- a/README.md
+++ b/README.md
@@ -40,41 +40,49 @@ and currently does not support version 3.8 and above. It is recommended to insta
 
 To set up on your local machine:
 
-To install core utilities, CPU-based algorithms, and dependencies:
+* To install core utilities, CPU-based algorithms, and dependencies:
 
-1. Ensure software required for compilation and Python libraries is installed. On Linux this can be supported by adding:
-```bash
-sudo apt-get install -y build-essential libpython<version>
-``` 
-where `<version>` should be `3.6` or `3.7` as appropriate.
+    1. Ensure software required for compilation and Python libraries
+       is installed. On Linux this can be supported by adding:
+    
+       ```bash
+       sudo apt-get install -y build-essential libpython<version>
+       ``` 
+    
+       where `<version>` should be `3.6` or `3.7` as appropriate.
+    
+       On Windows you will need [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+      
+    2. Create a conda or virtual environment.  See the
+       [setup guide](SETUP.md) for more details.
+    
+    3. Within the created environment, install the package from
+       [PyPI](https://pypi.org):
+    
+       ```bash
+       pip install --upgrade pip
+       pip install --upgrade setuptools
+       pip install recommenders[examples]
+       ```
+    
+    4. Register your (conda or virtual) environment with Jupyter:
+    
+       ```bash
+       python -m ipykernel install --user --name my_environment_name --display-name "Python (reco)"
+       ```
+    
+    5. Start the Jupyter notebook server
+    
+       ```bash
+       jupyter notebook
+       ```
+    
+    6. Run the [SAR Python CPU MovieLens](examples/00_quick_start/sar_movielens.ipynb)
+       notebook under the `00_quick_start` folder. Make sure to change
+       the kernel to "Python (reco)".
 
-On Windows you will need [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
-  
-2. Create a conda or virtual environment. See the [setup guide](SETUP.md) for more details.
-
-3. Within the created environment, install the package from [PyPI](https://pypi.org):
-
-```bash
-pip install --upgrade pip
-pip install --upgrade setuptools
-pip install recommenders[examples]
-```
-
-4. Register your (conda or virtual) environment with Jupyter:
-
-```bash
-python -m ipykernel install --user --name my_environment_name --display-name "Python (reco)"
-```
-
-5. Start the Jupyter notebook server
-
-```bash
-jupyter notebook
-```
-
-6. Run the [SAR Python CPU MovieLens](examples/00_quick_start/sar_movielens.ipynb) notebook under the `00_quick_start` folder. Make sure to change the kernel to "Python (reco)".
-
-For additional options to install the package (support for GPU, Spark etc.) see [this guide](recommenders/README.md).
+* For additional options to install the package (support for GPU,
+  Spark etc.) see [this guide](recommenders/README.md).
 
 **NOTE** - The [Alternating Least Squares (ALS)](examples/00_quick_start/als_movielens.ipynb) notebooks require a PySpark environment to run. Please follow the steps in the [setup guide](SETUP.md#dependencies-setup) to run these notebooks in a PySpark environment. For the deep learning algorithms, it is recommended to use a GPU machine and to follow the steps in the [setup guide](SETUP.md#dependencies-setup) to set up Nvidia libraries.
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The [Getting Started](https://github.com/microsoft/recommenders/blob/staging/README.md#getting-started) section in README.md is a little messy.  For example:

4. Register your (conda or virtual) environment with Jupyter:

   ```bash
   python -m ipykernel install --user --name my_environment_name --display-name "Python (reco)"
   ```

5. Start the Jupyter notebook server

   ```bash
   jupyter notebook
   ```

will look better than:

4. Register your (conda or virtual) environment with Jupyter:

```bash
python -m ipykernel install --user --name my_environment_name --display-name "Python (reco)"
```

5. Start the Jupyter notebook server

```bash
jupyter notebook
```

Please compare [getting started@simonz/format-getting-started](https://github.com/microsoft/recommenders/blob/simonz/format-getting-started/README.md#getting-started) with [getting started@staging](https://github.com/microsoft/recommenders/blob/staging/README.md)

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [X] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
