### PR TITLE
Fix notebook build failure on Spark 3.2

### DIFF
--- a/examples/00_quick_start/als_movielens.ipynb
+++ b/examples/00_quick_start/als_movielens.ipynb
@@ -2,34 +2,46 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "<i>Copyright (c) Microsoft Corporation. All rights reserved.</i>\n",
     "\n",
     "<i>Licensed under the MIT License.</i>"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Running ALS on MovieLens (PySpark)\n",
     "\n",
     "Matrix factorization by [ALS](https://spark.apache.org/docs/latest/api/python/_modules/pyspark/ml/recommendation.html#ALS) (Alternating Least Squares) is a well known collaborative filtering algorithm.\n",
     "\n",
     "This notebook provides an example of how to utilize and evaluate ALS PySpark ML (DataFrame-based API) implementation, meant for large-scale distributed datasets. We use a smaller dataset in this example to run ALS efficiently on multiple cores of a [Data Science Virtual Machine](https://azure.microsoft.com/en-gb/services/virtual-machines/data-science-virtual-machines/)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "**Note**: This notebook requires a PySpark environment to run properly. Please follow the steps in [SETUP.md](../../SETUP.md) to install the PySpark environment."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "System version: 3.8.0 (default, Nov  6 2019, 21:49:08) \n",
+      "[GCC 7.3.0]\n",
+      "Spark version: 3.2.0\n"
+     ]
+    }
+   ],
    "source": [
     "# set the environment path to find Recommenders\n",
     "import sys\n",
@@ -49,30 +61,24 @@
     "\n",
     "print(\"System version: {}\".format(sys.version))\n",
     "print(\"Spark version: {}\".format(pyspark.__version__))\n"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "System version: 3.6.8 |Anaconda, Inc.| (default, Dec 30 2018, 01:22:34) \n",
-      "[GCC 7.3.0]\n",
-      "Spark version: 2.3.1\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Set the default parameters."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
    "source": [
     "# top k items to recommend\n",
     "TOP_K = 10\n",
@@ -85,69 +91,69 @@
     "COL_ITEM = \"MovieId\"\n",
     "COL_RATING = \"Rating\"\n",
     "COL_TIMESTAMP = \"Timestamp\""
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### 0. Set up Spark context\n",
     "\n",
     "The following settings work well for debugging locally on VM - change when running on a cluster. We set up a giant single executor with many threads and specify memory cap. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "22/01/13 16:26:50 WARN Utils: Your hostname, pdfocal resolves to a loopback address: 127.0.1.1; using 10.211.55.61 instead (on interface enp0s5)\n",
+      "22/01/13 16:26:50 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "WARNING: An illegal reflective access operation has occurred\n",
+      "WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/home/test/miniconda3/envs/reco/lib/python3.8/site-packages/pyspark/jars/spark-unsafe_2.12-3.2.0.jar) to constructor java.nio.DirectByteBuffer(long,int)\n",
+      "WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\n",
+      "WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\n",
+      "WARNING: All illegal access operations will be denied in a future release\n",
+      "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
+      "22/01/13 16:26:51 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+     ]
+    }
    ],
-   "metadata": {}
+   "source": [
+    "# the following settings work well for debugging locally on VM - change when running on a cluster\n",
+    "# set up a giant single executor with many threads and specify memory cap\n",
+    "spark = start_or_get_spark(\"ALS PySpark\", memory=\"16g\", config={\"spark.sql.analyzer.failAmbiguousSelfJoin\": \"false\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Download the MovieLens dataset"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "# the following settings work well for debugging locally on VM - change when running on a cluster\n",
-    "# set up a giant single executor with many threads and specify memory cap\n",
-    "spark = start_or_get_spark(\"ALS PySpark\", memory=\"16g\")"
-   ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "### 1. Download the MovieLens dataset"
-   ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "source": [
-    "# Note: The DataFrame-based API for ALS currently only supports integers for user and item ids.\n",
-    "schema = StructType(\n",
-    "    (\n",
-    "        StructField(COL_USER, IntegerType()),\n",
-    "        StructField(COL_ITEM, IntegerType()),\n",
-    "        StructField(COL_RATING, FloatType()),\n",
-    "        StructField(COL_TIMESTAMP, LongType()),\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "data = movielens.load_spark_df(spark, size=MOVIELENS_DATA_SIZE, schema=schema)\n",
-    "data.show()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "100%|██████████| 4.81k/4.81k [00:00<00:00, 19.9kKB/s]\n"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4.81k/4.81k [00:20<00:00, 239KB/s]\n",
+      "                                                                                \r"
      ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "+------+-------+------+---------+\n",
       "|UserId|MovieId|Rating|Timestamp|\n",
@@ -178,48 +184,63 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Note: The DataFrame-based API for ALS currently only supports integers for user and item ids.\n",
+    "schema = StructType(\n",
+    "    (\n",
+    "        StructField(COL_USER, IntegerType()),\n",
+    "        StructField(COL_ITEM, IntegerType()),\n",
+    "        StructField(COL_RATING, FloatType()),\n",
+    "        StructField(COL_TIMESTAMP, LongType()),\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "data = movielens.load_spark_df(spark, size=MOVIELENS_DATA_SIZE, schema=schema)\n",
+    "data.show()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### 2. Split the data using the Spark random splitter provided in utilities"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N train 75018\n",
+      "N test 24982\n"
+     ]
+    }
+   ],
    "source": [
     "train, test = spark_random_split(data, ratio=0.75, seed=123)\n",
     "print (\"N train\", train.cache().count())\n",
     "print (\"N test\", test.cache().count())"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "N train 75193\n",
-      "N test 24807\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### 3. Train the ALS model on the training data, and get the top-k recommendations for our testing data\n",
     "\n",
     "To predict movie ratings, we use the rating data in the training set as users' explicit feedback. The hyperparameters used in building the model are referenced from [here](http://mymedialite.net/examples/datasets.html). We do not constrain the latent factors (`nonnegative = False`) in order to allow for both positive and negative preferences towards movies.\n",
     "Timing will vary depending on the machine being used to train."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "header = {\n",
     "    \"userCol\": COL_USER,\n",
@@ -238,42 +259,75 @@
     "    seed=42,\n",
     "    **header\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "22/01/13 16:27:59 WARN InstanceBuilder$NativeBLAS: Failed to load implementation from:dev.ludovic.netlib.blas.JNIBLAS\n",
+      "22/01/13 16:27:59 WARN InstanceBuilder$NativeBLAS: Failed to load implementation from:dev.ludovic.netlib.blas.ForeignLinkerBLAS\n",
+      "22/01/13 16:27:59 WARN InstanceBuilder$NativeLAPACK: Failed to load implementation from:dev.ludovic.netlib.lapack.JNILAPACK\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Took 10.751604393999514 seconds for training.\n"
+     ]
+    }
+   ],
    "source": [
     "with Timer() as train_time:\n",
     "    model = als.fit(train)\n",
     "\n",
     "print(\"Took {} seconds for training.\".format(train_time.interval))"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Took 3.2410509269684553 seconds for training.\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "In the movie recommendation use case, recommending movies that have been rated by the users do not make sense. Therefore, the rated movies are removed from the recommended items.\n",
     "\n",
     "In order to achieve this, we recommend all movies to all users, and then remove the user-movie pairs that exist in the training dataset."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "22/01/13 16:28:12 WARN Column: Constructing trivially true equals predicate, 'UserId#0 = UserId#0'. Perhaps you need to use aliases.\n",
+      "[Stage 126:===================================================> (194 + 2) / 200]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Took 25.308568059001118 seconds for prediction.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                                \r"
+     ]
+    }
+   ],
    "source": [
     "with Timer() as test_time:\n",
     "\n",
@@ -298,81 +352,111 @@
     "    top_all.cache().count()\n",
     "\n",
     "print(\"Took {} seconds for prediction.\".format(test_time.interval))"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Took 10.559875106438994 seconds for prediction.\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "source": [
-    "top_all.show()"
-   ],
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "+------+-------+----------+\n",
       "|UserId|MovieId|prediction|\n",
       "+------+-------+----------+\n",
-      "|     1|    587| 3.0676804|\n",
-      "|     1|    869| 2.4396753|\n",
-      "|     1|   1208| 3.2788403|\n",
-      "|     1|   1357| 2.0567489|\n",
-      "|     1|   1677| 2.9661644|\n",
-      "|     2|     80| 2.3442159|\n",
-      "|     2|    472|  3.060428|\n",
-      "|     2|    582|  3.489215|\n",
-      "|     2|    838| 1.0985656|\n",
-      "|     2|    975| 1.8764799|\n",
-      "|     2|   1260| 3.0814102|\n",
-      "|     2|   1381|  3.288192|\n",
-      "|     2|   1530| 1.9368806|\n",
-      "|     3|     22| 4.2560363|\n",
-      "|     3|     57|  3.295701|\n",
-      "|     3|     89|  4.983886|\n",
-      "|     3|    367| 2.5427854|\n",
-      "|     3|   1091| 1.4424214|\n",
-      "|     3|   1167| 2.2066739|\n",
-      "|     3|   1499|  3.368075|\n",
+      "|     1|    587| 4.1602826|\n",
+      "|     1|    869| 2.7732866|\n",
+      "|     1|   1208| 2.0333834|\n",
+      "|     1|   1348| 1.0019258|\n",
+      "|     1|   1357| 0.9430025|\n",
+      "|     1|   1677| 2.8777318|\n",
+      "|     2|     80|  2.351385|\n",
+      "|     2|    472| 2.5865324|\n",
+      "|     2|    582| 3.9548614|\n",
+      "|     2|    838| 0.9482964|\n",
+      "|     2|    975| 3.1133537|\n",
+      "|     2|   1260| 1.9871742|\n",
+      "|     2|   1325| 1.2368056|\n",
+      "|     2|   1381| 3.5477588|\n",
+      "|     2|   1530| 2.0882902|\n",
+      "|     3|     22| 3.1524534|\n",
+      "|     3|     57| 3.6980166|\n",
+      "|     3|     89| 3.9733818|\n",
+      "|     3|    367| 3.6629043|\n",
+      "|     3|   1091| 0.9144471|\n",
       "+------+-------+----------+\n",
       "only showing top 20 rows\n",
       "\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "top_all.show()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### 4. Evaluate how well ALS performs"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/test/miniconda3/envs/reco/lib/python3.8/site-packages/pyspark/sql/context.py:125: FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.\n",
+      "  warnings.warn(\n",
+      "                                                                                \r"
+     ]
+    }
+   ],
    "source": [
     "rank_eval = SparkRankingEvaluation(test, top_all, k = TOP_K, col_user=COL_USER, col_item=COL_ITEM, \n",
     "                                    col_rating=COL_RATING, col_prediction=\"prediction\", \n",
     "                                    relevancy_method=\"top_k\")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[Stage 463:>                                                        (0 + 2) / 2]\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model:\tALS\n",
+      "Top K:\t10\n",
+      "MAP:\t0.006527\n",
+      "NDCG:\t0.051718\n",
+      "Precision@K:\t0.051274\n",
+      "Recall@K:\t0.018840\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                                \r"
+     ]
+    }
+   ],
    "source": [
     "print(\"Model:\\tALS\",\n",
     "      \"Top K:\\t%d\" % rank_eval.k,\n",
@@ -380,77 +464,103 @@
     "      \"NDCG:\\t%f\" % rank_eval.ndcg_at_k(),\n",
     "      \"Precision@K:\\t%f\" % rank_eval.precision_at_k(),\n",
     "      \"Recall@K:\\t%f\" % rank_eval.recall_at_k(), sep='\\n')"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Model:\tALS\n",
-      "Top K:\t10\n",
-      "MAP:\t0.005734\n",
-      "NDCG:\t0.047460\n",
-      "Precision@K:\t0.051911\n",
-      "Recall@K:\t0.017514\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### 5. Evaluate rating prediction"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "source": [
-    "# Generate predicted ratings.\n",
-    "prediction = model.transform(test)\n",
-    "prediction.cache().show()\n"
-   ],
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
      "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 499:==========>  (169 + 2) / 200][Stage 500:====>           (3 + 0) / 10]\r",
+      "\r",
+      "[Stage 499:============>(185 + 2) / 200][Stage 500:====>           (3 + 0) / 10]\r"
+     ]
+    },
+    {
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "+------+-------+------+---------+----------+\n",
       "|UserId|MovieId|Rating|Timestamp|prediction|\n",
       "+------+-------+------+---------+----------+\n",
-      "|   406|    148|   3.0|879540276| 2.2832825|\n",
-      "|    27|    148|   3.0|891543129| 1.7940072|\n",
-      "|   606|    148|   3.0|878150506| 3.7863157|\n",
-      "|   916|    148|   2.0|880843892| 2.3045797|\n",
-      "|   236|    148|   4.0|890117028| 1.9480721|\n",
-      "|   602|    148|   4.0|888638517| 3.1172547|\n",
-      "|   663|    148|   4.0|889492989| 2.7976327|\n",
-      "|   372|    148|   5.0|876869915|  4.170663|\n",
-      "|   190|    148|   4.0|891033742| 3.6491241|\n",
-      "|     1|    148|   2.0|875240799|  2.829558|\n",
-      "|   297|    148|   3.0|875239619| 2.1554093|\n",
-      "|   178|    148|   4.0|882824325|  3.932391|\n",
-      "|   308|    148|   3.0|887740788| 2.9132738|\n",
-      "|   923|    148|   4.0|880387474| 3.5403519|\n",
-      "|    54|    148|   3.0|880937490|  3.165133|\n",
-      "|   430|    148|   2.0|877226047|  2.891675|\n",
-      "|    92|    148|   2.0|877383934| 2.6483998|\n",
-      "|   447|    148|   4.0|878854729| 3.1101565|\n",
-      "|   374|    148|   4.0|880392992| 2.2130618|\n",
-      "|   891|    148|   5.0|891639793|  3.138905|\n",
+      "|   580|    148|   4.0|884125773| 3.4059544|\n",
+      "|   406|    148|   3.0|879540276| 2.7134616|\n",
+      "|   916|    148|   2.0|880843892|  2.224198|\n",
+      "|   663|    148|   4.0|889492989| 2.7143617|\n",
+      "|   330|    148|   4.0|876544781|   4.52321|\n",
+      "|   935|    148|   4.0|884472892| 4.3838587|\n",
+      "|   308|    148|   3.0|887740788|  2.616949|\n",
+      "|    20|    148|   5.0|879668713|   4.37212|\n",
+      "|   923|    148|   4.0|880387474| 3.9818575|\n",
+      "|   455|    148|   3.0|879110346|  3.076419|\n",
+      "|    15|    148|   3.0|879456049| 2.9913845|\n",
+      "|   374|    148|   4.0|880392992| 3.2223387|\n",
+      "|   880|    148|   2.0|880167030| 2.8111987|\n",
+      "|   677|    148|   4.0|889399265| 3.8451848|\n",
+      "|    49|    148|   1.0|888068195| 1.3751595|\n",
+      "|   244|    148|   2.0|880605071| 2.6781514|\n",
+      "|    84|    148|   4.0|883452274| 3.6721768|\n",
+      "|   627|    148|   3.0|879530463|  2.636207|\n",
+      "|   434|    148|   3.0|886724797| 3.0973825|\n",
+      "|   793|    148|   4.0|875104498| 2.2886577|\n",
       "+------+-------+------+---------+----------+\n",
       "only showing top 20 rows\n",
       "\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "[Stage 500:============================>                           (5 + 2) / 10]\r",
+      "\r",
+      "                                                                                \r"
+     ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Generate predicted ratings.\n",
+    "prediction = model.transform(test)\n",
+    "prediction.cache().show()\n"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model:\tALS rating prediction\n",
+      "RMSE:\t0.967434\n",
+      "MAE:\t0.753340\n",
+      "Explained variance:\t0.265916\n",
+      "R squared:\t0.259532\n"
+     ]
+    }
+   ],
    "source": [
     "rating_eval = SparkRatingEvaluation(test, prediction, col_user=COL_USER, col_item=COL_ITEM, \n",
     "                                    col_rating=COL_RATING, col_prediction=\"prediction\")\n",
@@ -460,25 +570,230 @@
     "      \"MAE:\\t%f\" % rating_eval.mae(),\n",
     "      \"Explained variance:\\t%f\" % rating_eval.exp_var(),\n",
     "      \"R squared:\\t%f\" % rating_eval.rsquared(), sep='\\n')"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Model:\tALS rating prediction\n",
-      "RMSE:\t0.967296\n",
-      "MAE:\t0.753306\n",
-      "Explained variance:\t0.261864\n",
-      "R squared:\t0.255480\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/test/miniconda3/envs/reco/lib/python3.8/site-packages/papermill/iorw.py:50: FutureWarning: pyarrow.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.\n",
+      "  from pyarrow import HadoopFileSystem\n"
+     ]
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.006527288768086336,
+       "encoder": "json",
+       "name": "map",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "map"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.051717802220247217,
+       "encoder": "json",
+       "name": "ndcg",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "ndcg"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.05127388535031851,
+       "encoder": "json",
+       "name": "precision",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "precision"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.018840283525491316,
+       "encoder": "json",
+       "name": "recall",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "recall"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.9674342218475348,
+       "encoder": "json",
+       "name": "rmse",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "rmse"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.7533395123214025,
+       "encoder": "json",
+       "name": "mae",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "mae"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.2659161988067019,
+       "encoder": "json",
+       "name": "exp_var",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "exp_var"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.25953227528757383,
+       "encoder": "json",
+       "name": "rsquared",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "rsquared"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 10.751604393999514,
+       "encoder": "json",
+       "name": "train_time",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "train_time"
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 25.308568059001118,
+       "encoder": "json",
+       "name": "test_time",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "test_time"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "if is_jupyter():\n",
     "    # Record results with papermill for tests\n",
@@ -494,26 +809,24 @@
     "    sb.glue(\"rsquared\", rating_eval.rsquared())\n",
     "    sb.glue(\"train_time\", train_time.interval)\n",
     "    sb.glue(\"test_time\", test_time.interval)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# cleanup spark instance\n",
     "spark.stop()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (reco_pyspark)",
+   "display_name": "Python (reco)",
    "language": "python",
-   "name": "reco_pyspark"
+   "name": "reco"
   },
   "language_info": {
    "codemirror_mode": {
@@ -525,7 +838,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/examples/02_model_content_based_filtering/mmlspark_lightgbm_criteo.ipynb
+++ b/examples/02_model_content_based_filtering/mmlspark_lightgbm_criteo.ipynb
@@ -2,15 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "<i>Copyright (c) Microsoft Corporation. All rights reserved.</i>\n",
     "\n",
     "<i>Licensed under the MIT License.</i>"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Content-Based Personalization with LightGBM on Spark\n",
     "\n",
@@ -22,30 +23,235 @@
     "[MMLSpark](https://github.com/Azure/mmlspark) library, which allows LightGBM to be called in a Spark environment and be computed distributely.\n",
     "\n",
     "This scenario is a good example of **implicit feedback**, where binary labels indicate the interaction between a user and an item. This contrasts with explicit feedback, where the user explicitely rate the content, for example from 1 to 5. \n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Global Settings and Imports"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "This notebook can be run in a Spark environment in a DSVM or in Azure Databricks. For more details about the installation process, please refer to the [setup instructions](../../SETUP.md).\n",
     "\n",
     "**NOTE for Azure Databricks:**\n",
     "* A python script is provided to simplify setting up Azure Databricks with the correct dependencies. Run ```python tools/databricks_install.py -h``` for more details.\n",
     "* MMLSpark should not be run on a cluster with autoscaling enabled. Disable the flag in the Azure Databricks Cluster configuration before running this notebook."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/test/miniconda3/envs/reco/lib/python3.8/site-packages/papermill/iorw.py:50: FutureWarning: pyarrow.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.\n",
+      "  from pyarrow import HadoopFileSystem\n",
+      "22/01/13 16:16:59 WARN Utils: Your hostname, pdfocal resolves to a loopback address: 127.0.1.1; using 10.211.55.61 instead (on interface enp0s5)\n",
+      "22/01/13 16:16:59 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "WARNING: An illegal reflective access operation has occurred\n",
+      "WARNING: Illegal reflective access by org.apache.spark.unsafe.Platform (file:/home/test/miniconda3/envs/reco/lib/python3.8/site-packages/pyspark/jars/spark-unsafe_2.12-3.2.0.jar) to constructor java.nio.DirectByteBuffer(long,int)\n",
+      "WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\n",
+      "WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\n",
+      "WARNING: All illegal access operations will be denied in a future release\n",
+      "https://mmlspark.azureedge.net/maven added as a remote repository with the name: repo-1\n",
+      "Ivy Default Cache set to: /home/test/.ivy2/cache\n",
+      "The jars for the packages stored in: /home/test/.ivy2/jars\n",
+      "com.microsoft.azure#synapseml_2.12 added as a dependency\n",
+      ":: resolving dependencies :: org.apache.spark#spark-submit-parent-ce9ee5c2-f4dd-4ec0-a707-ccde714f9519;1.0\n",
+      "\tconfs: [default]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":: loading settings :: url = jar:file:/home/test/miniconda3/envs/reco/lib/python3.8/site-packages/pyspark/jars/ivy-2.5.0.jar!/org/apache/ivy/core/settings/ivysettings.xml\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\tfound com.microsoft.azure#synapseml_2.12;0.9.5 in central\n",
+      "\tfound com.microsoft.azure#synapseml-core_2.12;0.9.5 in central\n",
+      "\tfound org.scalactic#scalactic_2.12;3.0.5 in central\n",
+      "\tfound org.scala-lang#scala-reflect;2.12.4 in central\n",
+      "\tfound io.spray#spray-json_2.12;1.3.2 in central\n",
+      "\tfound com.jcraft#jsch;0.1.54 in central\n",
+      "\tfound org.apache.httpcomponents#httpclient;4.5.6 in central\n",
+      "\tfound org.apache.httpcomponents#httpcore;4.4.10 in central\n",
+      "\tfound commons-logging#commons-logging;1.2 in central\n",
+      "\tfound commons-codec#commons-codec;1.10 in central\n",
+      "\tfound org.apache.httpcomponents#httpmime;4.5.6 in central\n",
+      "\tfound com.linkedin.isolation-forest#isolation-forest_3.2.0_2.12;2.0.8 in central\n",
+      "\tfound com.chuusai#shapeless_2.12;2.3.2 in central\n",
+      "\tfound org.typelevel#macro-compat_2.12;1.1.1 in central\n",
+      "\tfound org.apache.spark#spark-avro_2.12;3.2.0 in central\n",
+      "\tfound org.tukaani#xz;1.8 in central\n",
+      "\tfound org.spark-project.spark#unused;1.0.0 in central\n",
+      "\tfound org.testng#testng;6.8.8 in central\n",
+      "\tfound org.beanshell#bsh;2.0b4 in central\n",
+      "\tfound com.beust#jcommander;1.27 in central\n",
+      "\tfound com.microsoft.azure#synapseml-deep-learning_2.12;0.9.5 in central\n",
+      "\tfound com.microsoft.azure#synapseml-opencv_2.12;0.9.5 in central\n",
+      "\tfound org.openpnp#opencv;3.2.0-1 in central\n",
+      "\tfound com.microsoft.cntk#cntk;2.4 in central\n",
+      "\tfound com.microsoft.onnxruntime#onnxruntime_gpu;1.8.1 in central\n",
+      "\tfound com.microsoft.azure#synapseml-cognitive_2.12;0.9.5 in central\n",
+      "\tfound com.microsoft.cognitiveservices.speech#client-jar-sdk;1.14.0 in central\n",
+      "\tfound com.azure#azure-storage-blob;12.14.2 in central\n",
+      "\tfound com.azure#azure-core;1.22.0 in central\n",
+      "\tfound com.fasterxml.jackson.core#jackson-annotations;2.12.5 in central\n",
+      "\tfound com.fasterxml.jackson.core#jackson-core;2.12.5 in central\n",
+      "\tfound com.fasterxml.jackson.core#jackson-databind;2.12.5 in central\n",
+      "\tfound com.fasterxml.jackson.datatype#jackson-datatype-jsr310;2.12.5 in central\n",
+      "\tfound com.fasterxml.jackson.dataformat#jackson-dataformat-xml;2.12.5 in central\n",
+      "\tfound com.fasterxml.jackson.module#jackson-module-jaxb-annotations;2.12.5 in central\n",
+      "\tfound jakarta.xml.bind#jakarta.xml.bind-api;2.3.2 in central\n",
+      "\tfound jakarta.activation#jakarta.activation-api;1.2.1 in central\n",
+      "\tfound org.codehaus.woodstox#stax2-api;4.2.1 in central\n",
+      "\tfound com.fasterxml.woodstox#woodstox-core;6.2.4 in central\n",
+      "\tfound org.slf4j#slf4j-api;1.7.32 in central\n",
+      "\tfound io.projectreactor#reactor-core;3.4.10 in central\n",
+      "\tfound org.reactivestreams#reactive-streams;1.0.3 in central\n",
+      "\tfound io.netty#netty-tcnative-boringssl-static;2.0.43.Final in central\n",
+      "\tfound com.azure#azure-core-http-netty;1.11.2 in central\n",
+      "\tfound io.netty#netty-handler;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-common;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-resolver;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-buffer;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-transport;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-codec;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-handler-proxy;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-codec-socks;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-codec-http;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-codec-http2;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-transport-native-unix-common;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-transport-native-epoll;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-transport-native-kqueue;4.1.68.Final in central\n",
+      "\tfound io.projectreactor.netty#reactor-netty-http;1.0.11 in central\n",
+      "\tfound io.netty#netty-resolver-dns;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-codec-dns;4.1.68.Final in central\n",
+      "\tfound io.netty#netty-resolver-dns-native-macos;4.1.68.Final in central\n",
+      "\tfound io.projectreactor.netty#reactor-netty-core;1.0.11 in central\n",
+      "\tfound com.azure#azure-storage-common;12.14.1 in central\n",
+      "\tfound com.azure#azure-storage-internal-avro;12.1.2 in central\n",
+      "\tfound com.azure#azure-ai-textanalytics;5.1.4 in central\n",
+      "\tfound com.microsoft.azure#synapseml-vw_2.12;0.9.5 in central\n",
+      "\tfound com.github.vowpalwabbit#vw-jni;8.9.1 in central\n",
+      "\tfound com.microsoft.azure#synapseml-lightgbm_2.12;0.9.5 in central\n",
+      "\tfound com.microsoft.ml.lightgbm#lightgbmlib;3.2.110 in central\n",
+      ":: resolution report :: resolve 1916ms :: artifacts dl 83ms\n",
+      "\t:: modules in use:\n",
+      "\tcom.azure#azure-ai-textanalytics;5.1.4 from central in [default]\n",
+      "\tcom.azure#azure-core;1.22.0 from central in [default]\n",
+      "\tcom.azure#azure-core-http-netty;1.11.2 from central in [default]\n",
+      "\tcom.azure#azure-storage-blob;12.14.2 from central in [default]\n",
+      "\tcom.azure#azure-storage-common;12.14.1 from central in [default]\n",
+      "\tcom.azure#azure-storage-internal-avro;12.1.2 from central in [default]\n",
+      "\tcom.beust#jcommander;1.27 from central in [default]\n",
+      "\tcom.chuusai#shapeless_2.12;2.3.2 from central in [default]\n",
+      "\tcom.fasterxml.jackson.core#jackson-annotations;2.12.5 from central in [default]\n",
+      "\tcom.fasterxml.jackson.core#jackson-core;2.12.5 from central in [default]\n",
+      "\tcom.fasterxml.jackson.core#jackson-databind;2.12.5 from central in [default]\n",
+      "\tcom.fasterxml.jackson.dataformat#jackson-dataformat-xml;2.12.5 from central in [default]\n",
+      "\tcom.fasterxml.jackson.datatype#jackson-datatype-jsr310;2.12.5 from central in [default]\n",
+      "\tcom.fasterxml.jackson.module#jackson-module-jaxb-annotations;2.12.5 from central in [default]\n",
+      "\tcom.fasterxml.woodstox#woodstox-core;6.2.4 from central in [default]\n",
+      "\tcom.github.vowpalwabbit#vw-jni;8.9.1 from central in [default]\n",
+      "\tcom.jcraft#jsch;0.1.54 from central in [default]\n",
+      "\tcom.linkedin.isolation-forest#isolation-forest_3.2.0_2.12;2.0.8 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml-cognitive_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml-core_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml-deep-learning_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml-lightgbm_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml-opencv_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml-vw_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.azure#synapseml_2.12;0.9.5 from central in [default]\n",
+      "\tcom.microsoft.cntk#cntk;2.4 from central in [default]\n",
+      "\tcom.microsoft.cognitiveservices.speech#client-jar-sdk;1.14.0 from central in [default]\n",
+      "\tcom.microsoft.ml.lightgbm#lightgbmlib;3.2.110 from central in [default]\n",
+      "\tcom.microsoft.onnxruntime#onnxruntime_gpu;1.8.1 from central in [default]\n",
+      "\tcommons-codec#commons-codec;1.10 from central in [default]\n",
+      "\tcommons-logging#commons-logging;1.2 from central in [default]\n",
+      "\tio.netty#netty-buffer;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-codec;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-codec-dns;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-codec-http;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-codec-http2;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-codec-socks;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-common;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-handler;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-handler-proxy;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-resolver;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-resolver-dns;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-resolver-dns-native-macos;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-tcnative-boringssl-static;2.0.43.Final from central in [default]\n",
+      "\tio.netty#netty-transport;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-transport-native-epoll;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-transport-native-kqueue;4.1.68.Final from central in [default]\n",
+      "\tio.netty#netty-transport-native-unix-common;4.1.68.Final from central in [default]\n",
+      "\tio.projectreactor#reactor-core;3.4.10 from central in [default]\n",
+      "\tio.projectreactor.netty#reactor-netty-core;1.0.11 from central in [default]\n",
+      "\tio.projectreactor.netty#reactor-netty-http;1.0.11 from central in [default]\n",
+      "\tio.spray#spray-json_2.12;1.3.2 from central in [default]\n",
+      "\tjakarta.activation#jakarta.activation-api;1.2.1 from central in [default]\n",
+      "\tjakarta.xml.bind#jakarta.xml.bind-api;2.3.2 from central in [default]\n",
+      "\torg.apache.httpcomponents#httpclient;4.5.6 from central in [default]\n",
+      "\torg.apache.httpcomponents#httpcore;4.4.10 from central in [default]\n",
+      "\torg.apache.httpcomponents#httpmime;4.5.6 from central in [default]\n",
+      "\torg.apache.spark#spark-avro_2.12;3.2.0 from central in [default]\n",
+      "\torg.beanshell#bsh;2.0b4 from central in [default]\n",
+      "\torg.codehaus.woodstox#stax2-api;4.2.1 from central in [default]\n",
+      "\torg.openpnp#opencv;3.2.0-1 from central in [default]\n",
+      "\torg.reactivestreams#reactive-streams;1.0.3 from central in [default]\n",
+      "\torg.scala-lang#scala-reflect;2.12.4 from central in [default]\n",
+      "\torg.scalactic#scalactic_2.12;3.0.5 from central in [default]\n",
+      "\torg.slf4j#slf4j-api;1.7.32 from central in [default]\n",
+      "\torg.spark-project.spark#unused;1.0.0 from central in [default]\n",
+      "\torg.testng#testng;6.8.8 from central in [default]\n",
+      "\torg.tukaani#xz;1.8 from central in [default]\n",
+      "\torg.typelevel#macro-compat_2.12;1.1.1 from central in [default]\n",
+      "\t---------------------------------------------------------------------\n",
+      "\t|                  |            modules            ||   artifacts   |\n",
+      "\t|       conf       | number| search|dwnlded|evicted|| number|dwnlded|\n",
+      "\t---------------------------------------------------------------------\n",
+      "\t|      default     |   69  |   0   |   0   |   0   ||   69  |   0   |\n",
+      "\t---------------------------------------------------------------------\n",
+      ":: retrieving :: org.apache.spark#spark-submit-parent-ce9ee5c2-f4dd-4ec0-a707-ccde714f9519\n",
+      "\tconfs: [default]\n",
+      "\t0 artifacts copied, 69 already retrieved (0kB/37ms)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "22/01/13 16:17:02 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MMLSpark version: com.microsoft.azure:synapseml_2.12:0.9.5\n",
+      "System version: 3.8.0 (default, Nov  6 2019, 21:49:08) \n",
+      "[GCC 7.3.0]\n",
+      "PySpark version: 3.2.0\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import sys\n",
@@ -64,35 +270,31 @@
     "\n",
     "# Setup MML Spark\n",
     "from recommenders.utils.spark_utils import MMLSPARK_REPO, MMLSPARK_PACKAGE\n",
+    "\n",
+    "# On Spark >3.0.0,<3.2.0, the following should be set:\n",
+    "#     MMLSPARK_PACKAGE = \"com.microsoft.azure:synapseml_2.12:0.9.4\"\n",
     "packages = [MMLSPARK_PACKAGE]\n",
     "repos = [MMLSPARK_REPO]\n",
     "spark = start_or_get_spark(packages=packages, repositories=repos)\n",
     "dbutils = None\n",
     "print(\"MMLSpark version: {}\".format(MMLSPARK_PACKAGE))\n",
     "\n",
-    "from mmlspark.train import ComputeModelStatistics\n",
-    "from mmlspark.lightgbm import LightGBMClassifier\n",
+    "from synapse.ml.train import ComputeModelStatistics\n",
+    "from synapse.ml.lightgbm import LightGBMClassifier\n",
     "\n",
     "print(\"System version: {}\".format(sys.version))\n",
     "print(\"PySpark version: {}\".format(pyspark.version.__version__))"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "MMLSpark version: com.microsoft.ml.spark:mmlspark_2.11:0.18.1\n",
-      "System version: 3.6.10 |Anaconda, Inc.| (default, May  8 2020, 02:54:21) \n",
-      "[GCC 7.3.0]\n",
-      "PySpark version: 2.4.3\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
    "source": [
     "# Criteo data size, it can be \"sample\" or \"full\"\n",
     "DATA_SIZE = \"sample\"\n",
@@ -107,43 +309,34 @@
     "\n",
     "# Model name\n",
     "MODEL_NAME = 'lightgbm_criteo.mml'"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Data Preparation\n",
     "\n",
     "The [Criteo Display Advertising Challenge](https://www.kaggle.com/c/criteo-display-ad-challenge) (Criteo DAC) dataset is a well-known industry benchmarking dataset for developing CTR prediction models, and is used frequently by research papers. The original dataset contains over 45M rows, but there is also a down-sampled dataset which has 100,000 rows (this can be used by setting `DATA_SIZE = \"sample\"`). Each row corresponds to a display ad served by Criteo and the first column is indicates whether this ad has been clicked or not.<br><br>\n",
     "The dataset contains 1 label column and 39 feature columns, where 13 columns are integer values (int00-int12) and 26 columns are categorical features (cat00-cat25).<br><br>\n",
     "What the columns represent is not provided, but for this case we can consider the integer and categorical values as features representing the user and / or item content. The label is binary and is an example of implicit feedback indicating a user's interaction with an item. With this dataset we can demonstrate how to build a model that predicts the probability of a user interacting with an item based on available user and item content features.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "source": [
-    "raw_data = load_spark_df(size=DATA_SIZE, spark=spark, dbutils=dbutils)\n",
-    "# visualize data\n",
-    "raw_data.limit(2).toPandas().head()"
-   ],
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "100%|██████████| 8.58k/8.58k [00:01<00:00, 5.15kKB/s]\n"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 8.58k/8.58k [00:27<00:00, 317KB/s]\n",
+      "22/01/13 16:19:09 WARN package: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.\n",
+      "                                                                                \r"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -257,53 +450,59 @@
        "[2 rows x 40 columns]"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 4
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "raw_data = load_spark_df(size=DATA_SIZE, spark=spark, dbutils=dbutils)\n",
+    "# visualize data\n",
+    "raw_data.limit(2).toPandas().head()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Feature Processing\n",
     "The feature data provided has many missing values across both integer and categorical feature fields. In addition the categorical features have many distinct values, so effectively cleaning and representing the feature data is an important step prior to training a model.<br><br>\n",
     "One of the simplest ways of managing both features that have missing values as well as high cardinality is to use the hashing trick. The [FeatureHasher](http://spark.apache.org/docs/latest/ml-features.html#featurehasher) transformer will pass integer values through and will hash categorical features into a sparse vector of lower dimensionality, which can be used effectively by LightGBM.<br><br>\n",
     "First, the dataset is splitted randomly for training and testing and feature processing is applied to each dataset."
-   ],
-   "metadata": {}
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_train, raw_test = spark_random_split(raw_data, ratio=0.8, seed=42)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "raw_train, raw_test = spark_random_split(raw_data, ratio=0.8, seed=42)"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "columns = [c for c in raw_data.columns if c != 'label']\n",
+    "feature_processor = FeatureHasher(inputCols=columns, outputCol='features')"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "source": [
-    "columns = [c for c in raw_data.columns if c != 'label']\n",
-    "feature_processor = FeatureHasher(inputCols=columns, outputCol='features')"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
    "source": [
     "train = feature_processor.transform(raw_train)\n",
     "test = feature_processor.transform(raw_test)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Model Training\n",
     "In MMLSpark, the LightGBM implementation for binary classification is invoked using the `LightGBMClassifier` class and specifying the objective as `\"binary\"`. In this instance, the occurrence of positive labels is quite low, so setting the `isUnbalance` flag to true helps account for this imbalance.<br><br>\n",
@@ -315,12 +514,13 @@
     "- `learningRate`: the learning rate for training across trees\n",
     "- `featureFraction`: the fraction of features used for training a tree\n",
     "- `earlyStoppingRound`: round at which early stopping can be applied to avoid overfitting"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "lgbm = LightGBMClassifier(\n",
     "    labelCol=\"label\",\n",
@@ -336,38 +536,67 @@
     "    featureFraction=FEATURE_FRACTION,\n",
     "    earlyStoppingRound=EARLY_STOPPING_ROUND\n",
     ")"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Model Training and Evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
    ],
-   "metadata": {}
+   "source": [
+    "model = lgbm.fit(train)\n"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "source": [
-    "model = lgbm.fit(train)\n"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "predictions = model.transform(test)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "source": [
-    "predictions = model.transform(test)"
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "22/01/13 16:20:07 WARN DAGScheduler: Broadcasting large task binary with size 5.0 MiB\n",
+      "22/01/13 16:20:09 WARN DAGScheduler: Broadcasting large task binary with size 5.0 MiB\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------------+------------------+\n",
+      "|evaluation_type|               AUC|\n",
+      "+---------------+------------------+\n",
+      "| Classification|0.6613923527503233|\n",
+      "+---------------+------------------+\n",
+      "\n"
+     ]
+    }
    ],
-   "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
    "source": [
     "evaluator = (\n",
     "    ComputeModelStatistics()\n",
@@ -379,89 +608,83 @@
     "result = evaluator.transform(predictions)\n",
     "auc = result.select(\"AUC\").collect()[0][0]\n",
     "result.show()"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "+---------------+------------------+\n",
-      "|evaluation_type|               AUC|\n",
-      "+---------------+------------------+\n",
-      "| Classification|0.6892773832319504|\n",
-      "+---------------+------------------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/scrapbook.scrap.json+json": {
+       "data": 0.6613923527503233,
+       "encoder": "json",
+       "name": "auc",
+       "version": 1
+      }
+     },
+     "metadata": {
+      "scrapbook": {
+       "data": true,
+       "display": false,
+       "name": "auc"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Record results with papermill for tests\n",
     "sb.glue(\"auc\", auc)"
-   ],
-   "outputs": [
-    {
-     "output_type": "display_data",
-     "data": {
-      "application/papermill.record+json": {
-       "auc": 0.6870253907336659
-      }
-     },
-     "metadata": {}
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Model Saving \n",
     "The full pipeline for operating on raw data including feature processing and model prediction can be saved and reloaded for use in another workflow."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# save model\n",
     "pipeline = PipelineModel(stages=[feature_processor, model])\n",
     "pipeline.write().overwrite().save(MODEL_NAME)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# cleanup spark instance\n",
     "if not is_databricks():\n",
     "    spark.stop()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Additional Reading\n",
     "\\[1\\] Guolin Ke, Qi Meng, Thomas Finley, Taifeng Wang, Wei Chen, Weidong Ma, Qiwei Ye, and Tie-Yan Liu. 2017. LightGBM: A highly efficient gradient boosting decision tree. In Advances in Neural Information Processing Systems. 3146–3154. https://papers.nips.cc/paper/6907-lightgbm-a-highly-efficient-gradient-boosting-decision-tree.pdf <br>\n",
     "\\[2\\] MML Spark: https://mmlspark.blob.core.windows.net/website/index.html <br>\n"
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "reco_full",
+   "display_name": "Python (reco)",
    "language": "python",
-   "name": "conda-env-reco_full-py"
+   "name": "reco"
   },
   "language_info": {
    "codemirror_mode": {
@@ -473,7 +696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/recommenders/utils/spark_utils.py
+++ b/recommenders/utils/spark_utils.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     pass  # skip this import if we are in pure python environment
 
-MMLSPARK_PACKAGE = "com.microsoft.ml.spark:mmlspark:1.0.0-rc3-184-3314e164-SNAPSHOT"
+MMLSPARK_PACKAGE = "com.microsoft.azure:synapseml_2.12:0.9.5"
 MMLSPARK_REPO = "https://mmlspark.azureedge.net/maven"
 # We support Spark v3, but in case you wish to use v2, set
 # MMLSPARK_PACKAGE = "com.microsoft.ml.spark:mmlspark_2.11:0.18.1"

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ extras_require = {
     "spark": [
         "databricks_cli>=0.8.6,<1",
         "pyarrow>=0.12.1,<7.0.0",
-        "pyspark>=2.4.5,<3.2.0",
+        "pyspark>=2.4.5,<4.0.0",
     ],
     "dev": [
         "black>=18.6b4,<21",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Spark 3.2 introduces breaking changes that make code written for Spark version below 3.2 incompatible.  This PR fixed modified the notebook to be compatible with Spark 3.2.  The dependency that are affected is MMLSpark which is now renamed to SynapseML.
However, the latest SynapseML (SynapseML 0.9.5) do not support Spark version below 3.2.  To use Spark 3.0 and 3.1, SynapseML 0.9.4 should be used.  This difference is also pointed out in the comments of [mmlspark_lightgbm_criteo.ipynb](https://github.com/microsoft/recommenders/blob/simonz/build-failure-on-spark3.2/examples/02_model_content_based_filtering/mmlspark_lightgbm_criteo.ipynb).

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
See #1553 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [X] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
