### PR TITLE
remove early stopping round from lightgbm example notebook

### DIFF
--- a/examples/02_model_content_based_filtering/mmlspark_lightgbm_criteo.ipynb
+++ b/examples/02_model_content_based_filtering/mmlspark_lightgbm_criteo.ipynb
@@ -115,7 +115,6 @@
     "NUM_ITERATIONS = 50\n",
     "LEARNING_RATE = 0.1\n",
     "FEATURE_FRACTION = 0.8\n",
-    "EARLY_STOPPING_ROUND = 10\n",
     "\n",
     "# Model name\n",
     "MODEL_NAME = 'lightgbm_criteo.mml'"
@@ -321,8 +320,7 @@
     "- `numLeaves`: the number of leaves in each tree\n",
     "- `numIterations`: the number of iterations to apply boosting\n",
     "- `learningRate`: the learning rate for training across trees\n",
-    "- `featureFraction`: the fraction of features used for training a tree\n",
-    "- `earlyStoppingRound`: round at which early stopping can be applied to avoid overfitting"
+    "- `featureFraction`: the fraction of features used for training a tree"
    ]
   },
   {
@@ -342,8 +340,7 @@
     "    numLeaves=NUM_LEAVES,\n",
     "    numIterations=NUM_ITERATIONS,\n",
     "    learningRate=LEARNING_RATE,\n",
-    "    featureFraction=FEATURE_FRACTION,\n",
-    "    earlyStoppingRound=EARLY_STOPPING_ROUND\n",
+    "    featureFraction=FEATURE_FRACTION\n",
     ")"
    ]
   },

--- a/tests/integration/examples/test_notebooks_pyspark.py
+++ b/tests/integration/examples/test_notebooks_pyspark.py
@@ -53,7 +53,7 @@ def test_mmlspark_lightgbm_criteo_integration(notebooks, output_notebook, kernel
         notebook_path,
         output_notebook,
         kernel_name=kernel_name,
-        parameters=dict(DATA_SIZE="full", NUM_ITERATIONS=50, EARLY_STOPPING_ROUND=10),
+        parameters=dict(DATA_SIZE="full", NUM_ITERATIONS=50),
     )
     results = sb.read_notebook(output_notebook).scraps.dataframe.set_index("name")[
         "data"

--- a/tests/smoke/examples/test_notebooks_pyspark.py
+++ b/tests/smoke/examples/test_notebooks_pyspark.py
@@ -53,7 +53,7 @@ def test_mmlspark_lightgbm_criteo_smoke(notebooks, output_notebook, kernel_name)
         notebook_path,
         output_notebook,
         kernel_name=kernel_name,
-        parameters=dict(DATA_SIZE="sample", NUM_ITERATIONS=50, EARLY_STOPPING_ROUND=10),
+        parameters=dict(DATA_SIZE="sample", NUM_ITERATIONS=50),
     )
 
     results = sb.read_notebook(output_notebook).scraps.dataframe.set_index("name")[

--- a/tests/unit/examples/test_notebooks_pyspark.py
+++ b/tests/unit/examples/test_notebooks_pyspark.py
@@ -132,5 +132,5 @@ def test_mmlspark_lightgbm_criteo_runs(notebooks, output_notebook, kernel_name):
         notebook_path,
         output_notebook,
         kernel_name=kernel_name,
-        parameters=dict(DATA_SIZE="sample", NUM_ITERATIONS=10, EARLY_STOPPING_ROUND=2),
+        parameters=dict(DATA_SIZE="sample", NUM_ITERATIONS=10),
     )


### PR DESCRIPTION

### Description
remove early stopping round from lightgbm example notebook since it isn't used


### Related Issues
This is a related issue to this minor notebook patch:
https://github.com/microsoft/recommenders/issues/1615


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
