### PR TITLE
Add back scikit-surprise to dependencies 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,7 @@ To setup the documentation, first you need to install the dependencies of the fu
     conda create -n reco_full -c conda-forge python=3.7 cudatoolkit=11.2 cudnn=8.1
     conda activate reco_full
 
-    pip install numpy cython
-    pip install --no-binary scikit-surprise "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz"
+    pip install numpy
     pip install "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip"
     pip install sphinx_rtd_theme
 

--- a/recommenders/README.md
+++ b/recommenders/README.md
@@ -70,7 +70,6 @@ We are currently evaluating inclusion of the following dependencies:
 ## Other dependencies
 
 Some dependencies are not available via the recommenders PyPI package, but can be installed in the following ways: 
- - scikit-surprise: due to incompatibilities with `numpy <= 1.19`, proper installation of Surprise requires `pip install numpy cython` and `pip install --no-binary scikit-surprise "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz"`
  - pymanopt: this dependency is required for the RLRMC and GeoIMC algorithms; a version of this code compatible with TensorFlow 2 can be
  installed with `pip install "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip"`. 
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ install_requires = [
     "cornac>=1.1.2,<2",
     "retrying>=1.3.3",
     "pandera[strategies]>=0.6.5",  # For generating fake datasets
+    "scikit-surprise>=1.0.6"
 ]
 
 # shared dependencies
@@ -99,10 +100,7 @@ extras_require["nni"] = [
     "nni==1.5",
 ]
 
-# The following dependencies can be installed as below, however PyPI does not allow direct URLs.
-# Surprise needs to be built from source because of the numpy <= 1.19 incompatibility
-# Requires pip to be run with the --no-binary option
-# "scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz",
+# The following dependency can be installed as below, however PyPI does not allow direct URLs.
 # Temporary fix for pymanopt, only this commit works with TF2
 # "pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip",
 

--- a/tests/ci/azure_pipeline_test/dsvm_nightly_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_nightly_linux_cpu.yml
@@ -33,6 +33,6 @@ extends:
     timeout: 180 
     conda_env: "nightly_linux_cpu"
     conda_opts: "python=3.7"
-    pip_opts: "[examples,dev,experimental] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
+    pip_opts: "[examples,dev,experimental] 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache"
     pytest_markers: "not spark and not gpu"
     pytest_params: "-x"

--- a/tests/ci/azure_pipeline_test/dsvm_notebook_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_notebook_linux_cpu.yml
@@ -60,5 +60,5 @@ extends:
     task_name: "Test - Unit Notebook Linux CPU"
     conda_env: "unit_notebook_linux_cpu"
     conda_opts: "python=3.7"
-    pip_opts: "[examples,dev,experimental] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
+    pip_opts: "[examples,dev,experimental] 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache"
     pytest_markers: "notebooks and not spark and not gpu"

--- a/tests/ci/azure_pipeline_test/dsvm_unit_linux_cpu.yml
+++ b/tests/ci/azure_pipeline_test/dsvm_unit_linux_cpu.yml
@@ -60,5 +60,5 @@ extends:
     task_name: "Test - Unit Linux CPU"
     conda_env: "unit_linux_cpu"
     conda_opts: "python=3.7"
-    pip_opts: "[dev,experimental] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
+    pip_opts: "[dev,experimental] 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache"
     pytest_markers: "not notebooks and not spark and not gpu"

--- a/tests/ci/azure_pipeline_test/release_pipeline.yml
+++ b/tests/ci/azure_pipeline_test/release_pipeline.yml
@@ -23,7 +23,7 @@ jobs:
     task_name: "Test - Unit Linux CPU"
     conda_env: "release_unit_linux_cpu"
     conda_opts: "python=3.7"
-    pip_opts: "[experimental,dev] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
+    pip_opts: "[experimental,dev] 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache"
     pytest_markers: "not notebooks and not spark and not gpu"
     install: "release"
     package: "publish" 
@@ -35,7 +35,7 @@ jobs:
     task_name: "Test - Unit Notebook Linux CPU"
     conda_env: "release_unit_notebook_linux_cpu"
     conda_opts: "python=3.7"
-    pip_opts: "[experimental,examples,dev] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
+    pip_opts: "[experimental,examples,dev] 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache"
     pytest_markers: "notebooks and not spark and not gpu"
     install: "release"
 
@@ -93,7 +93,7 @@ jobs:
     timeout: 180 
     conda_env: "release_nightly_linux_cpu"
     conda_opts: "python=3.7"
-    pip_opts: "[experimental,examples,dev] 'scikit-surprise@https://github.com/NicolasHug/Surprise/archive/refs/tags/v1.1.1.tar.gz' 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache --no-binary scikit-surprise"
+    pip_opts: "[experimental,examples,dev] 'pymanopt@https://github.com/pymanopt/pymanopt/archive/fb36a272cdeecb21992cfd9271eb82baafeb316d.zip' --no-cache"
     pytest_markers: "not spark and not gpu"
     install: "release"
 

--- a/tests/integration/examples/test_notebooks_python.py
+++ b/tests/integration/examples/test_notebooks_python.py
@@ -91,7 +91,6 @@ def test_baseline_deep_dive_integration(
         assert results[key] == pytest.approx(value, rel=TOL, abs=ABS_TOL)
 
 
-@pytest.mark.experimental
 @pytest.mark.integration
 @pytest.mark.parametrize(
     "size, expected_values",

--- a/tests/smoke/examples/test_notebooks_python.py
+++ b/tests/smoke/examples/test_notebooks_python.py
@@ -56,7 +56,6 @@ def test_baseline_deep_dive_smoke(notebooks, output_notebook, kernel_name):
     assert results["recall"] == pytest.approx(0.108826, rel=TOL, abs=ABS_TOL)
 
 
-@pytest.mark.experimental
 @pytest.mark.smoke
 def test_surprise_svd_smoke(notebooks, output_notebook, kernel_name):
     notebook_path = notebooks["surprise_svd_deep_dive"]

--- a/tests/unit/examples/test_notebooks_python.py
+++ b/tests/unit/examples/test_notebooks_python.py
@@ -49,7 +49,6 @@ def test_baseline_deep_dive_runs(notebooks, output_notebook, kernel_name):
     pm.execute_notebook(notebook_path, output_notebook, kernel_name=kernel_name)
 
 
-@pytest.mark.experimental
 @pytest.mark.notebooks
 def test_surprise_deep_dive_runs(notebooks, output_notebook, kernel_name):
     notebook_path = notebooks["surprise_svd_deep_dive"]

--- a/tests/unit/recommenders/models/test_surprise_utils.py
+++ b/tests/unit/recommenders/models/test_surprise_utils.py
@@ -52,7 +52,6 @@ def rating_true():
     )
 
 
-@pytest.mark.experimental
 def test_predict(rating_true):
     svd = surprise.SVD()
     train_set = surprise.Dataset.load_from_df(
@@ -87,7 +86,6 @@ def test_predict(rating_true):
     ].values == pytest.approx(svd.predict(user, item).est, rel=TOL)
 
 
-@pytest.mark.experimental
 def test_recommend_k_items(rating_true):
     n_users = len(rating_true["userID"].unique())
     n_items = len(rating_true["itemID"].unique())


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Surprise has been disabled from setup.py because of an incompatibility with numpy 1.19.
I tested again surprise after the latest changes in the setup and the tests pass.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/microsoft/recommenders/issues/1511

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
