### PR TITLE
Set Spark env variables in nightly test

### DIFF
--- a/.github/workflows/actions/run-tests/action.yml
+++ b/.github/workflows/actions/run-tests/action.yml
@@ -47,6 +47,12 @@ runs:
       sudo apt-get install -y build-essential libpython3.6 libpython3.7
       pip install tox
   
+  - name: Set PYSPARK environment variables
+    shell: bash
+    run: |
+      export PYSPARK_DRIVER_PYTHON=$(which python)
+      export PYSPARK_PYTHON=$(which python)
+
   - name: Run ${{ inputs.test-kind }} tests ('${{ inputs.test-marker }}')
     shell: bash
     # '-e py' will use the default 'python' executable found in system path

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,9 @@ extras = dev,gpu,examples
 # with this dependency subset, we should be able to run the test markers:
 # 1. "spark and not notebook and not spark" (test for spark utilities)
 # 2. "spark and notebooks and not spark" (tests for notebook using spark)
+# passenv is used for the PYSPARK_PYTHON, PYSPARK_DRIVER_PYTHON env variables
 extras = dev,spark,examples
+passenv = *
 
 [testenv:all]
 # i.e: 'pip install recommenders-*.whl[all]'


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The PYSPARK env variables are not set properly in the nightly GitHub tests. 
This leads to some test failures:
https://github.com/microsoft/recommenders/runs/5359762687?check_suite_focus=true

_E             File "/home/azureuser/localfiles/runner/work/recommenders/recommenders/.tox/spark/lib/python3.7/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 485, in main
E               ("%d.%d" % sys.version_info[:2], version))
E           RuntimeError: Python in worker has different version 3.6 than that in driver 3.7, PySpark cannot run with different minor versions. Please check environment variables PYSPARK_PYTHON and PYSPARK_DRIVER_PYTHON are correctly set._


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
