### PR TITLE
Set Spark env variables in tox for nightly test

### DIFF
--- a/.github/workflows/actions/run-tests/action.yml
+++ b/.github/workflows/actions/run-tests/action.yml
@@ -47,12 +47,6 @@ runs:
       sudo apt-get install -y build-essential libpython3.6 libpython3.7
       pip install tox
   
-  - name: Set PYSPARK environment variables
-    shell: bash
-    run: |
-      export PYSPARK_DRIVER_PYTHON=$(which python)
-      export PYSPARK_PYTHON=$(which python)
-
   - name: Run ${{ inputs.test-kind }} tests ('${{ inputs.test-marker }}')
     shell: bash
     # '-e py' will use the default 'python' executable found in system path

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,9 @@ extras = dev,gpu,examples
 # 2. "spark and notebooks and not spark" (tests for notebook using spark)
 # passenv is used for the PYSPARK_PYTHON, PYSPARK_DRIVER_PYTHON env variables
 extras = dev,spark,examples
-passenv = *
+setenv =
+       PYSPARK_DRIVER_PYTHON = {envpython}
+       PYSPARK_PYTHON = {envpython}
 
 [testenv:all]
 # i.e: 'pip install recommenders-*.whl[all]'


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

The PYSPARK env variables are not set properly in the nightly GitHub tests. This leads to some test failures.
#1655 did not fix this, instead the environment variables should be set inside tox.ini.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
