### PR TITLE
Codecov Fix

### DIFF
--- a/.github/workflows/actions/merge-cov/action.yml
+++ b/.github/workflows/actions/merge-cov/action.yml
@@ -33,9 +33,18 @@ runs:
   # different parallelized runs
   - name: Merge coverage reports
     shell: bash
+    # NOTE: Merging code reports generated from self-hosted (aml) runners can be problematic
+    #       as reports may reference the source code at an unresolvable absolute path.
+    #       For example, you may encounter errors like:
+    #            "CoverageWarning: Couldn't parse 
+    #            '/home/azureuser/runner/work/recommenders/recommenders/recommenders/evaluation/__init__.py':
+    #            No source for code"
+    # Work-around: Creating a symlink at the root that points to the default local runner folder: '/home/runner/work/recommenders'
     run: |
+      sudo mkdir -p /home/azureuser
+      sudo ln -s /home/runner /home/azureuser/runner
       python -m coverage combine .coverage*
-      python -m coverage report
+      python -m coverage report -i
       python -m coverage xml -i
       
   - name: Show merged report

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -176,7 +176,10 @@ jobs:
         # different kinds of tests are located in tests/<unit|integration|smoke> folders
         test-kind: ['unit'] 
         # pytest markers configured in tox.ini. See https://docs.pytest.org/en/6.2.x/example/markers.html
-        test-marker: ['gpu and notebooks and not spark and not experimental', 'gpu and not notebooks and not spark and not experimental']
+        test-marker: [
+          'gpu and not notebooks and not spark and not experimental', 
+          'gpu and notebooks and not spark and not experimental'
+        ]
 
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,7 @@ markers =
     # See https://docs.pytest.org/en/stable/example/markers.html#registering-markers
     deeprec: test deeprec model
     sequential: test sequential model
+    experimental: mark a test that has advanced build requirements or might conflict with libraries from other options
     notebooks: mark a test as notebooks test
     smoke: mark a test as smoke test
     integration: mark a test as integration test


### PR DESCRIPTION
### Description
Resolves the following issue when merging code coverage reports generated in self-hosted (aml) runners.

```
"CoverageWarning: Couldn't parse 
 '/home/azureuser/runner/work/recommenders/recommenders/recommenders/evaluation/__init__.py': No source for code"
```
Also add `-i` flag to ignore the "No source for code" error.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
