### PR TITLE
Fix the docstring of LibffmConverter

### DIFF
--- a/recommenders/datasets/pandas_df_utils.py
+++ b/recommenders/datasets/pandas_df_utils.py
@@ -109,8 +109,8 @@ class LibffmConverter:
         The above data will be converted to the libffm format by following the convention as explained in
         `this paper <https://www.csie.ntu.edu.tw/~r01922136/slides/ffm.pdf>`_.
 
-        i.e. `<field_index>:<field_feature_index>:1` or `<field_index>:<field_index>:<field_feature_value>`, depending on
-        the data type of the features in the original dataframe.
+        i.e. `<field_index>:<field_feature_index>:1` or `<field_index>:<field_feature_index>:<field_feature_value>`,
+        depending on the data type of the features in the original dataframe.
 
     Args:
         filepath (str): path to save the converted data.


### PR DESCRIPTION
### Description
This PR aims to fix the typo mentioned in [[ASK] The docstring explanation for `LibffmConverter`](https://github.com/microsoft/recommenders/issues/1670). The corresponding docstring in `LibffmConverter` class was changed.


### Related Issues
[[ASK] The docstring explanation for `LibffmConverter`](https://github.com/microsoft/recommenders/issues/1670)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
