### PR TITLE
Persist intermediate data to avoid non-determinism caused by Spark lazy random evaluation

### DIFF
--- a/recommenders/datasets/spark_splitters.py
+++ b/recommenders/datasets/spark_splitters.py
@@ -128,6 +128,7 @@ def _do_stratification_spark(
         .withColumn("_rank", F.row_number().over(window_spec) / F.col("_count"))
         .drop("_count", col_random)
     )
+    # Persist to avoid duplicate rows in splits caused by lazy evaluation
     data.persist(StorageLevel.MEMORY_AND_DISK_2).count()
 
     multi_split, ratio = process_split_ratio(ratio)

--- a/recommenders/datasets/spark_splitters.py
+++ b/recommenders/datasets/spark_splitters.py
@@ -5,6 +5,7 @@ import numpy as np
 
 try:
     from pyspark.sql import functions as F, Window
+    from pyspark.sql.types import StructType, StructField, LongType
 except ImportError:
     pass  # skip this import if we are in pure python environment
 
@@ -109,15 +110,23 @@ def _do_stratification_spark(
             col_item=col_item,
         )
 
+    def _add_index_column(df, index_name):
+        # Add a index column to the data frame
+        return df.rdd.zipWithIndex().map(lambda row: row[0] + (row[1],)).toDF(
+            schema=StructType(df.schema.fields + [StructField(index_name, LongType(), False), ])
+        )
+
+    # Generate random numbers independent of the data
+    col_random = "__random_number"
+    col_index = "__col_index"
+    rand_numbers = spark.range(data.count()).orderBy(F.rand(seed=seed)).withColumnRenamed("id", col_random)
+    rand_numbers = _add_index_column(rand_numbers, col_index)
+    data = _add_index_column(data, col_index)
+    data = data.join(rand_numbers, on=col_index, how="inner").drop(col_index)
+
     split_by = col_user if filter_by == "user" else col_item
     partition_by = split_by if is_partitioned else []
-
-    if is_random:
-        col_random = "_random"
-        data = data.withColumn(col_random, F.rand(seed=seed))
-        order_by = F.col(col_random)
-    else:
-        order_by = F.col(col_timestamp)
+    order_by = F.col(col_random) if is_random else F.col(col_timestamp)
 
     window_count = Window.partitionBy(partition_by)
     window_spec = Window.partitionBy(partition_by).orderBy(order_by)
@@ -125,11 +134,8 @@ def _do_stratification_spark(
     data = (
         data.withColumn("_count", F.count(split_by).over(window_count))
         .withColumn("_rank", F.row_number().over(window_spec) / F.col("_count"))
-        .drop("_count")
+        .drop("_count", col_random)
     )
-
-    if is_random:
-        data = data.drop(col_random)
 
     multi_split, ratio = process_split_ratio(ratio)
     ratio = ratio if multi_split else [ratio, 1 - ratio]

--- a/recommenders/datasets/spark_splitters.py
+++ b/recommenders/datasets/spark_splitters.py
@@ -218,7 +218,7 @@ def spark_stratified_split(
             data into several portions corresponding to the split ratios. If a list is
             provided and the ratios are not summed to 1, they will be normalized.
             Earlier indexed splits will have earlier times
-            (e.g the latest time per user or item in split[0] <= the earliest time per user or item in split[1])
+            (e.g. the latest time per user or item in split[0] <= the earliest time per user or item in split[1])
         seed (int): Seed.
         min_rating (int): minimum number of ratings for user or item.
         filter_by (str): either "user" or "item", depending on which of the two is to filter
@@ -260,7 +260,7 @@ def spark_timestamp_split(
             data into several portions corresponding to the split ratios. If a list is
             provided and the ratios are not summed to 1, they will be normalized.
             Earlier indexed splits will have earlier times
-            (e.g the latest time in split[0] <= the earliest time in split[1])
+            (e.g. the latest time in split[0] <= the earliest time in split[1])
         col_user (str): column name of user IDs.
         col_item (str): column name of item IDs.
         col_timestamp (str): column name of timestamps. Float number represented in

--- a/recommenders/datasets/spark_splitters.py
+++ b/recommenders/datasets/spark_splitters.py
@@ -5,7 +5,6 @@ import numpy as np
 
 try:
     from pyspark.sql import functions as F, Window
-    from pyspark.sql.types import StructType, StructField, LongType
     from pyspark.storagelevel import StorageLevel
 except ImportError:
     pass  # skip this import if we are in pure python environment
@@ -127,12 +126,9 @@ def _do_stratification_spark(
     data = (
         data.withColumn("_count", F.count(split_by).over(window_count))
         .withColumn("_rank", F.row_number().over(window_spec) / F.col("_count"))
-        .drop("_count")
+        .drop("_count", col_random)
     )
     data.persist(StorageLevel.MEMORY_AND_DISK_2).count()
-
-    if is_random:
-        data = data.drop(col_random)
 
     multi_split, ratio = process_split_ratio(ratio)
     ratio = ratio if multi_split else [ratio, 1 - ratio]

--- a/tests/unit/recommenders/datasets/test_spark_splitter.py
+++ b/tests/unit/recommenders/datasets/test_spark_splitter.py
@@ -124,6 +124,13 @@ def test_stratified_splitter(spark_dataset):
     assert splits[0].count() / NUM_ROWS == pytest.approx(RATIOS[0], TOL)
     assert splits[1].count() / NUM_ROWS == pytest.approx(1 - RATIOS[0], TOL)
 
+    # Test if there is intersection
+    assert splits[0].intersect(splits[1]).count() == 0
+    splits = spark_stratified_split(
+        spark_dataset.repartition(4), ratio=RATIOS[0], filter_by="user", min_rating=10
+    )
+    assert splits[0].intersect(splits[1]).count() == 0
+
     # Test if both contains the same user list. This is because stratified split is stratified.
     users_train = (
         splits[0].select(DEFAULT_USER_COL).distinct().rdd.map(lambda r: r[0]).collect()
@@ -139,6 +146,15 @@ def test_stratified_splitter(spark_dataset):
     assert splits[0].count() / NUM_ROWS == pytest.approx(RATIOS[0], TOL)
     assert splits[1].count() / NUM_ROWS == pytest.approx(RATIOS[1], TOL)
     assert splits[2].count() / NUM_ROWS == pytest.approx(RATIOS[2], TOL)
+
+    # Test if there is intersection
+    assert splits[0].intersect(splits[1]).count() == 0
+    assert splits[0].intersect(splits[2]).count() == 0
+    assert splits[1].intersect(splits[2]).count() == 0
+    splits = spark_stratified_split(spark_dataset.repartition(9), ratio=RATIOS)
+    assert splits[0].intersect(splits[1]).count() == 0
+    assert splits[0].intersect(splits[2]).count() == 0
+    assert splits[1].intersect(splits[2]).count() == 0
 
 
 @pytest.mark.spark

--- a/tests/unit/recommenders/datasets/test_spark_splitter.py
+++ b/tests/unit/recommenders/datasets/test_spark_splitter.py
@@ -117,6 +117,8 @@ def test_chrono_splitter(spark_dataset):
 
 @pytest.mark.spark
 def test_stratified_splitter(spark_dataset):
+    spark_dataset = spark_dataset.dropDuplicates()
+
     splits = spark_stratified_split(
         spark_dataset, ratio=RATIOS[0], filter_by="user", min_rating=10
     )


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The bug is reported by Bhrigu.  Due to Spark lazy evaluation, random filtering without replacement in [`spark_stratified_split()`](https://github.com/microsoft/recommenders/blob/17204b1c3b676c80f729fe607e8d04e6b70c96a0/recommenders/datasets/spark_splitters.py#L115-L129) will result in duplicate rows in both training and test data.

This PR persists the intermediate data to avoid the issue caused by Spark lazy evaluation.

See also:
* [Avoid lazy evaluation of code in spark without cache](https://stackoverflow.com/questions/60513055/avoid-lazy-evaluation-of-code-in-spark-without-cache)
* [spark data modified after using random in filter method](https://stackoverflow.com/questions/61243909/spark-data-modified-after-using-random-in-filter-method)


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [X] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
