### PR TITLE
Change MovieLens URL from HTTP to HTTPS

### DIFF
--- a/examples/00_quick_start/ncf_movielens.ipynb
+++ b/examples/00_quick_start/ncf_movielens.ipynb
@@ -112,7 +112,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:recommenders.datasets.download_utils:Downloading http://files.grouplens.org/datasets/movielens/ml-100k.zip\n",
+      "INFO:recommenders.datasets.download_utils:Downloading https://files.grouplens.org/datasets/movielens/ml-100k.zip\n",
       "100%|██████████| 4.81k/4.81k [00:00<00:00, 16.9kKB/s]\n"
      ]
     }

--- a/examples/01_prepare_data/data_split.ipynb
+++ b/examples/01_prepare_data/data_split.ipynb
@@ -73,7 +73,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "source": [
-    "DATA_URL = \"http://files.grouplens.org/datasets/movielens/ml-100k/u.data\"\n",
+    "DATA_URL = \"https://files.grouplens.org/datasets/movielens/ml-100k/u.data\"\n",
     "DATA_PATH = \"ml-100k.data\"\n",
     "\n",
     "COL_USER = \"UserId\"\n",

--- a/examples/02_model_hybrid/lightfm_deep_dive.ipynb
+++ b/examples/02_model_hybrid/lightfm_deep_dive.ipynb
@@ -1030,7 +1030,7 @@
     }
    ],
    "source": [
-    "user_feature_URL = 'http://files.grouplens.org/datasets/movielens/ml-100k/u.user'\n",
+    "user_feature_URL = 'https://files.grouplens.org/datasets/movielens/ml-100k/u.user'\n",
     "user_data = pd.read_table(user_feature_URL, \n",
     "              sep='|', header=None)\n",
     "user_data.columns = ['userID','age','gender','occupation','zipcode']\n",

--- a/recommenders/datasets/movielens.py
+++ b/recommenders/datasets/movielens.py
@@ -159,7 +159,7 @@ def load_pandas_df(
 ):
     """Loads the MovieLens dataset as pd.DataFrame.
 
-    Download the dataset from http://files.grouplens.org/datasets/movielens, unzip, and load.
+    Download the dataset from https://files.grouplens.org/datasets/movielens, unzip, and load.
     To load movie information only, you can use load_item_df function.
 
     Args:
@@ -304,7 +304,7 @@ def _load_item_df(size, item_datapath, movie_col, title_col, genres_col, year_co
     genres_header_100k = None
     if genres_col is not None:
         # 100k data's movie genres are encoded as a binary array (the last 19 fields)
-        # For details, see http://files.grouplens.org/datasets/movielens/ml-100k-README.txt
+        # For details, see https://files.grouplens.org/datasets/movielens/ml-100k-README.txt
         if size == "100k":
             genres_header_100k = [*(str(i) for i in range(19))]
             item_header.extend(genres_header_100k)
@@ -366,7 +366,7 @@ def load_spark_df(
 ):
     """Loads the MovieLens dataset as `pyspark.sql.DataFrame`.
 
-    Download the dataset from http://files.grouplens.org/datasets/movielens, unzip, and load as `pyspark.sql.DataFrame`.
+    Download the dataset from https://files.grouplens.org/datasets/movielens, unzip, and load as `pyspark.sql.DataFrame`.
 
     To load movie information only, you can use `load_item_df` function.
 
@@ -552,7 +552,7 @@ def download_movielens(size, dest_path):
     if size not in DATA_FORMAT:
         raise ValueError(ERROR_MOVIE_LENS_SIZE)
 
-    url = "http://files.grouplens.org/datasets/movielens/ml-" + size + ".zip"
+    url = "https://files.grouplens.org/datasets/movielens/ml-" + size + ".zip"
     dirs, file = os.path.split(dest_path)
     maybe_download(url, file, work_directory=dirs)
 
@@ -587,7 +587,7 @@ class MockMovielensSchema(pa.SchemaModel):
     Mock dataset schema to generate fake data for testing purpose.
     This schema is configured to mimic the Movielens dataset
 
-    http://files.grouplens.org/datasets/movielens/ml-100k/
+    https://files.grouplens.org/datasets/movielens/ml-100k/
 
     Dataset schema and generation is configured using pandera.
     Please see https://pandera.readthedocs.io/en/latest/schema_models.html


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
All MovieLens' HTTP URLs are not accessible now.  This PR changes `http` to `https`.

For example, http://files.grouplens.org/datasets/movielens/ml-100k.zip is not available, but https://files.grouplens.org/datasets/movielens/ml-100k.zip is.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [X] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
