### PR TITLE
Use numpy divide in explained variance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # What's New
 
-## Update March 31, 2022
+## Update April 1, 2022
 
 We have a new release [Recommenders 1.1.0](https://github.com/microsoft/recommenders/releases/tag/1.1.0)! 
 We have introduced the SASRec and SSEPT algorithms that are based on transformers. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Documentation Status](https://readthedocs.org/projects/microsoft-recommenders/badge/?version=latest)](https://microsoft-recommenders.readthedocs.io/en/latest/?badge=latest)
 
-## What's New (March 31, 2022)
+## What's New (April 1, 2022)
 
 We have a new release [Recommenders 1.1.0](https://github.com/microsoft/recommenders/releases/tag/1.1.0)! 
 We have introduced the SASRec and SSEPT algorithms that are based on transformers. 

--- a/recommenders/evaluation/spark_evaluation.py
+++ b/recommenders/evaluation/spark_evaluation.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import numpy as np
 try:
     from pyspark.mllib.evaluation import RegressionMetrics, RankingMetrics
     from pyspark.sql import Window, DataFrame
@@ -158,7 +159,8 @@ class SparkRatingEvaluation:
             0
         ]
         var2 = self.y_pred_true.selectExpr("variance(label)").collect()[0][0]
-        return 1 - var1 / var2
+        # numpy divide is more tolerant to var2 being zero
+        return 1 - np.divide(var1, var2)
 
 
 class SparkRankingEvaluation:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Useful in cases when all true labels are the same and hence explained variance should equal minus infinity.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
