### PR TITLE
Fix dot operation in BaseModel.run_fast_eval

### DIFF
--- a/recommenders/models/newsrec/models/base_model.py
+++ b/recommenders/models/newsrec/models/base_model.py
@@ -416,7 +416,7 @@ class BaseModel:
         ) in tqdm(self.test_iterator.load_impression_from_file(behaviors_file)):
             pred = np.dot(
                 np.stack([news_vecs[i] for i in news_index], axis=0),
-                user_vecs[impr_index],
+                user_vecs[user_index],
             )
             group_impr_indexes.append(impr_index)
             group_labels.append(label)


### PR DESCRIPTION
Using `impr_index` for the user's index doesn't make any sense. I think we should use `user_index` instead.
For example, the for the first iteration `impr_index = 0` while `user_index = 175`

edit: closing after further investigation. I was just confused by the variables names.
