### PR TITLE
Add a fast failure in SAR+ if the similarity metric is not within the options 

### DIFF
--- a/contrib/sarplus/python/pysarplus/SARPlus.py
+++ b/contrib/sarplus/python/pysarplus/SARPlus.py
@@ -77,7 +77,10 @@ class SARPlus:
             "time_decay_half_life": time_decay_coefficient * 24 * 60 * 60,
             "threshold": threshold,
         }
-
+        if similarity_type not in [COOCCUR, JACCARD, LIFT]:
+            raise ValueError(
+                'Similarity type must be one of ["cooccurrence" | "jaccard" | "lift"]'
+            )
         self.similarity_type = similarity_type
         self.timedecay_formula = timedecay_formula
         self.item_similarity = None

--- a/contrib/sarplus/python/pysarplus/SARPlus.py
+++ b/contrib/sarplus/python/pysarplus/SARPlus.py
@@ -77,7 +77,7 @@ class SARPlus:
             "time_decay_half_life": time_decay_coefficient * 24 * 60 * 60,
             "threshold": threshold,
         }
-        if similarity_type not in [COOCCUR, JACCARD, LIFT]:
+        if similarity_type not in [SIM_COOCCUR, SIM_JACCARD, SIM_LIFT]:
             raise ValueError(
                 'Similarity type must be one of ["cooccurrence" | "jaccard" | "lift"]'
             )
@@ -116,13 +116,16 @@ class SARPlus:
             # following is the query which we want to run
 
             if self.header["time_now"] is None:
-                query = self._format("""
+                query = self._format(
+                    """
                     SELECT CAST(MAX({col_timestamp}) AS long)
                     FROM {prefix}df_train_input
-                """)
+                """
+                )
                 self.header["time_now"] = self.spark.sql(query).first()[0]
 
-            query = self._format("""
+            query = self._format(
+                """
                 SELECT {col_user},
                        {col_item},
                        SUM(
@@ -132,7 +135,8 @@ class SARPlus:
                 FROM {prefix}df_train_input
                 GROUP BY {col_user}, {col_item}
                 CLUSTER BY {col_user}
-            """)
+            """
+            )
 
             # replace with time-decayed version
             df = self.spark.sql(query)
@@ -307,7 +311,9 @@ class SARPlus:
             WHERE is.i1 = a.i1 AND i2 = b.i1
         """
             )
-        ).write.mode("overwrite").saveAsTable(self._format("{prefix}item_similarity_mapped"))
+        ).write.mode("overwrite").saveAsTable(
+            self._format("{prefix}item_similarity_mapped")
+        )
 
         cache_path_output = self.cache_path
         if self.cache_path.startswith("dbfs:"):
@@ -471,6 +477,8 @@ class SARPlus:
         if not use_cache:
             return self._recommend_k_items_slow(test, top_k, remove_seen)
         elif self.cache_path is not None:
-            return self._recommend_k_items_fast(test, top_k, remove_seen, n_user_prediction_partitions)
+            return self._recommend_k_items_fast(
+                test, top_k, remove_seen, n_user_prediction_partitions
+            )
         else:
             raise ValueError("No cache_path specified")

--- a/recommenders/models/sar/sar_singlenode.py
+++ b/recommenders/models/sar/sar_singlenode.py
@@ -15,9 +15,9 @@ from recommenders.utils.python_utils import (
 from recommenders.utils import constants
 
 
-COOCCUR = "cooccurrence"
-JACCARD = "jaccard"
-LIFT = "lift"
+SIM_COOCCUR = "cooccurrence"
+SIM_JACCARD = "jaccard"
+SIM_LIFT = "lift"
 
 logger = logging.getLogger()
 
@@ -38,7 +38,7 @@ class SARSingleNode:
         col_rating=constants.DEFAULT_RATING_COL,
         col_timestamp=constants.DEFAULT_TIMESTAMP_COL,
         col_prediction=constants.DEFAULT_PREDICTION_COL,
-        similarity_type=JACCARD,
+        similarity_type=SIM_JACCARD,
         time_decay_coefficient=30,
         time_now=None,
         timedecay_formula=False,
@@ -66,7 +66,7 @@ class SARSingleNode:
         self.col_timestamp = col_timestamp
         self.col_prediction = col_prediction
 
-        if similarity_type not in [COOCCUR, JACCARD, LIFT]:
+        if similarity_type not in [SIM_COOCCUR, SIM_JACCARD, SIM_LIFT]:
             raise ValueError(
                 'Similarity type must be one of ["cooccurrence" | "jaccard" | "lift"]'
             )
@@ -272,15 +272,15 @@ class SARSingleNode:
         self.item_frequencies = item_cooccurrence.diagonal()
 
         logger.info("Calculating item similarity")
-        if self.similarity_type == COOCCUR:
+        if self.similarity_type == SIM_COOCCUR:
             logger.info("Using co-occurrence based similarity")
             self.item_similarity = item_cooccurrence
-        elif self.similarity_type == JACCARD:
+        elif self.similarity_type == SIM_JACCARD:
             logger.info("Using jaccard based similarity")
             self.item_similarity = jaccard(item_cooccurrence).astype(
                 df[self.col_rating].dtype
             )
-        elif self.similarity_type == LIFT:
+        elif self.similarity_type == SIM_LIFT:
             logger.info("Using lift based similarity")
             self.item_similarity = lift(item_cooccurrence).astype(
                 df[self.col_rating].dtype
@@ -364,7 +364,9 @@ class SARSingleNode:
             idx = self.index2item
         else:
             if self.user_frequencies is None:
-                self.user_frequencies = self.user_affinity.getnnz(axis=1).astype("int64")
+                self.user_frequencies = self.user_affinity.getnnz(axis=1).astype(
+                    "int64"
+                )
             frequencies = self.user_frequencies
             col = self.col_user
             idx = self.index2user


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
We want to fail in the constructure instead in the fit method if we add a similarity like "coocurranceeaefsadf"



### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
