### PR TITLE
Support PRs from forked repos

### DIFF
--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -6,6 +6,11 @@
 name: azureml-unit-tests
 
 on:
+  # pull_request_target allows execution of workflows in the context
+  # of a base repository. When a PR is raised from a forked repo, it
+  # gives the workflow access to AZUREML_TEST_CREDENTIALS, stored as
+  # a repo level secret, which is needed to trigger execution of unit
+  # tests on AzureML compute.
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -6,14 +6,12 @@
 name: azureml-unit-tests
 
 on:
-  pull_request:
-    branches: [ staging, main ]
-
   pull_request_target:
     types:
       - opened
-    branches:    
-      - 'pradjoshi/pr_fork'
+    branches:
+      - 'staging'
+      - 'main'
 
   # enable manual trigger
   workflow_dispatch:

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -9,10 +9,11 @@ on:
   pull_request:
     branches: [ staging, main ]
 
-  # push:
-  #   # because we can't schedule runs for non-main branches,
-  #   # to ensure we are running the build on the staging branch, we can add push policy for it
-  #   branches: [pradjoshi/update_azureml_cluster]
+  pull_request_target:
+    types:
+      - opened
+    branches:    
+      - 'pradjoshi/pr_fork'
 
   # enable manual trigger
   workflow_dispatch:


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Triggering execution of unit tests on AzureML requires access to credentials, which are not accessible from a forked repository, causing unit tests triggered by the PRs from outside collaborators to fail with a login error. This PR addresses the issue by using `pull_request_target` trigger, which allows execution of workflows in the context of a base repository, thus granting access to the AzureML credentials.
Here is a sample PR from a forked repo that can now successfully trigger AzureML tests https://github.com/microsoft/recommenders/pull/1746

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
