### PR TITLE
SAR item similarity dtype correction

### DIFF
--- a/recommenders/models/sar/sar_singlenode.py
+++ b/recommenders/models/sar/sar_singlenode.py
@@ -277,14 +277,10 @@ class SARSingleNode:
             self.item_similarity = item_cooccurrence
         elif self.similarity_type == SIM_JACCARD:
             logger.info("Using jaccard based similarity")
-            self.item_similarity = jaccard(item_cooccurrence).astype(
-                df[self.col_rating].dtype
-            )
+            self.item_similarity = jaccard(item_cooccurrence)
         elif self.similarity_type == SIM_LIFT:
             logger.info("Using lift based similarity")
-            self.item_similarity = lift(item_cooccurrence).astype(
-                df[self.col_rating].dtype
-            )
+            self.item_similarity = lift(item_cooccurrence)
         else:
             raise ValueError("Unknown similarity type: {}".format(self.similarity_type))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def train_test_dummy_timestamp(pandas_dummy_timestamp):
 def demo_usage_data(header, sar_settings):
     # load the data
     data = pd.read_csv(sar_settings["FILE_DIR"] + "demoUsageNoDups.csv")
-    data["rating"] = pd.Series([1.0] * data.shape[0])
+    data["rating"] = pd.Series([1] * data.shape[0])
     data = data.rename(
         columns={
             "userId": header["col_user"],

--- a/tests/unit/recommenders/models/test_sar_singlenode.py
+++ b/tests/unit/recommenders/models/test_sar_singlenode.py
@@ -183,16 +183,16 @@ def test_sar_item_similarity(
             model.item2index,
         )
         assert np.array_equal(
-            true_item_similarity,
-            test_item_similarity.astype(true_item_similarity.dtype),
+            true_item_similarity.astype("float64"),
+            test_item_similarity.astype("float64"),
         )
     else:
         test_item_similarity = _rearrange_to_test(
             model.item_similarity, row_ids, col_ids, model.item2index, model.item2index
         )
         assert np.allclose(
-            true_item_similarity,
-            test_item_similarity.astype(true_item_similarity.dtype),
+            true_item_similarity.astype("float64"),
+            test_item_similarity.astype("float64"),
             atol=sar_settings["ATOL"],
         )
 

--- a/tests/unit/recommenders/models/test_sar_singlenode.py
+++ b/tests/unit/recommenders/models/test_sar_singlenode.py
@@ -183,16 +183,16 @@ def test_sar_item_similarity(
             model.item2index,
         )
         assert np.array_equal(
-            true_item_similarity.astype(test_item_similarity.dtype),
-            test_item_similarity,
+            true_item_similarity,
+            test_item_similarity.astype(true_item_similarity.dtype),
         )
     else:
         test_item_similarity = _rearrange_to_test(
             model.item_similarity, row_ids, col_ids, model.item2index, model.item2index
         )
         assert np.allclose(
-            true_item_similarity.astype(test_item_similarity.dtype),
-            test_item_similarity,
+            true_item_similarity,
+            test_item_similarity.astype(true_item_similarity.dtype),
             atol=sar_settings["ATOL"],
         )
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

In `sar_singlenode.py`, item similarity matrix is converted to the same dtype as `col_rating`:
https://github.com/microsoft/recommenders/blob/d4181cf1d1df6e71f7e6b202b0875bb3bd54150c/recommenders/models/sar/sar_singlenode.py#L278-L280

When the dtype of `col_rating` is `int`, all numbers will be rounded off to the nearest integer which is not expected:

```pycon
>>> import pandas as pd
>>> import numpy as np
>>> header = {
...     "col_user": "UserId",
...     "col_item": "MovieId",
...     "col_rating": "Rating",
... }
>>> ratings_dict = {
...     header["col_user"]: [1, 1, 2, 3, 3],
...     header["col_item"]: [1, 2, 1, 1, 3],
...     header["col_rating"]: [1, 2, 1, 1, 2],
... }
>>> df = pd.DataFrame(ratings_dict)
>>> df[header["col_rating"]].dtype
dtype('int64')
>>> from recommenders.models.sar import SAR
>>> model = SAR(**header, similarity_type="jaccard")
>>> model.fit(df)
>>> print(model.item_similarity)
[[1 0 0]
 [0 1 0]
 [0 0 1]]
```

The correct item similarity should be

```
[[1.         0.33333333 0.33333333]
 [0.33333333 1.         0.        ]
 [0.33333333 0.         1.        ]]
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
