### PR TITLE
Optimized Spark recall_at_k time performance

### DIFF
--- a/recommenders/evaluation/spark_evaluation.py
+++ b/recommenders/evaluation/spark_evaluation.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import numpy as np
+
 try:
     from pyspark.mllib.evaluation import RegressionMetrics, RankingMetrics
     from pyspark.sql import Window, DataFrame
@@ -322,9 +323,13 @@ class SparkRankingEvaluation:
         Return:
             float: recall at k (min=0, max=1).
         """
-        recall = self._items_for_user_all.rdd.map(
-            lambda x: float(len(set(x[0]).intersection(set(x[1])))) / float(len(x[1]))
-        ).mean()
+        df_hit = self._items_for_user_all.withColumn(
+            "hit", F.array_intersect(DEFAULT_PREDICTION_COL, "ground_truth")
+        )
+        df_hit = df_hit.withColumn("num_hit", F.size("hit"))
+        df_hit = df_hit.withColumn("num_actual", F.size("ground_truth"))
+        df_hit = df_hit.withColumn("per_hit", df_hit["num_hit"] / df_hit["num_actual"])
+        recall = df_hit.select(F.mean("per_hit")).collect()[0][0]
 
         return recall
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Optimized time performance of recall_at_k() in Spark evaluation metrics. 

The function is tested on the MovieLens 20m dataset with 138,493 users, and with TOP_K = 50 recommendations generated for each user. The time cost of evaluating the recall of the recommendations is reduced from 6.99s to 1.09s, indicating a 7x performance improvement.


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
