### PR TITLE
Explicitly list references in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,11 @@
 <!--- If it fixes an open issue, please link to the issue here. -->
 
 
+### References
+<!--- References would be helpful to understand the changes. -->
+<!--- References can be books, links, etc. -->
+
+
 ### Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
It may be helpful to explicitly mention the references in pull requests.  Thus reviewers can have a better understanding of the PRs, and are confident that authors have done researches about the issues.

The 'References' section can be taken as a complement to the 'Related Issues' in [the pull request template](https://github.com/microsoft/recommenders/blob/main/.github/PULL_REQUEST_TEMPLATE.md) when there are no issues associated with the PRs.

The idea comes from the PR https://github.com/microsoft/recommenders/pull/1797#issue-1310323560, where I added references in the comment to explain why the amendment to exclude paths in a GitHub workflow works.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
