### PR TITLE
replace append with pd.concat

### DIFF
--- a/recommenders/models/deeprec/DataModel/ImplicitCF.py
+++ b/recommenders/models/deeprec/DataModel/ImplicitCF.py
@@ -70,7 +70,7 @@ class ImplicitCF(object):
             list: train and test pandas.DataFrame Dataset, which have been reindexed and filtered.
 
         """
-        df = train if test is None else train.append(test)
+        df = train if test is None else pd.concat([train, test],axis=0,ignore_index=True)
 
         if self.user_idx is None:
             user_idx = df[[self.col_user]].drop_duplicates().reindex()


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Execution of `data = ImplicitCF(train, test, seed, col_user, col_item, col_rating)` issues the following warning:
```
/anaconda/envs/ncf-microsoft-env/lib/python3.9/site-packages/recommenders/models/deeprec/DataModel/ImplicitCF.py:73: FutureWarning: The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  df = train if test is None else train.append(test)
```

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [Not Applicable] I have added tests covering my contributions.
- [Not Applicable] I have updated the documentation accordingly.
- [X] This PR is being made to `staging branch` and not to `main branch`.
