### PR TITLE
Python generalized ndcg

### DIFF
--- a/recommenders/evaluation/python_evaluation.py
+++ b/recommenders/evaluation/python_evaluation.py
@@ -569,16 +569,16 @@ def ndcg_at_k(
     if df_hit.shape[0] == 0:
         return 0.0
 
-    df_dcg = df_hit.merge(rating_pred, on=["user_id", "item_id"]).merge(
-        rating_true, on=["user_id", "item_id"], how="outer"
+    df_dcg = df_hit.merge(rating_pred, on=[col_user, col_item]).merge(
+        rating_true, on=[col_user, col_item], how="outer"
     )
 
     if score_type == "binary":
         df_dcg["rel"] = 1
     elif score_type == "raw":
-        df_dcg["rel"] = df_dcg["rating"]
+        df_dcg["rel"] = df_dcg[col_rating]
     elif score_type == "exp":
-        df_dcg["rel"] = 2 ** df_dcg["rating"] - 1
+        df_dcg["rel"] = 2 ** df_dcg[col_rating] - 1
     else:
         raise ValueError("score_type must be one of 'binary', 'raw', 'exp'")
 
@@ -593,22 +593,22 @@ def ndcg_at_k(
     df_dcg["dcg"] = df_dcg["rel"] / discfun(1 + df_dcg["rank"])
 
     # calculate ideal discounted gain for each record
-    df_idcg = df_dcg.sort_values(["user_id", "rating"], ascending=False)
-    df_idcg["irank"] = df_idcg.groupby("user_id", as_index=False, sort=False)[
-        "rating"
+    df_idcg = df_dcg.sort_values([col_user, col_rating], ascending=False)
+    df_idcg["irank"] = df_idcg.groupby(col_user, as_index=False, sort=False)[
+        col_rating
     ].rank("first", ascending=False)
     df_idcg["idcg"] = df_idcg["rel"] / discfun(1 + df_idcg["irank"])
 
     # calculate actual DCG for each user
-    df_user = df_dcg.groupby("user_id", as_index=False, sort=False).agg({"dcg": "sum"})
+    df_user = df_dcg.groupby(col_user, as_index=False, sort=False).agg({"dcg": "sum"})
 
     # calculate ideal DCG for each user
     df_user = df_user.merge(
-        df_idcg.groupby("user_id", as_index=False, sort=False)
+        df_idcg.groupby(col_user, as_index=False, sort=False)
         .head(k)
-        .groupby("user_id", as_index=False, sort=False)
+        .groupby(col_user, as_index=False, sort=False)
         .agg({"idcg": "sum"}),
-        on="user_id",
+        on=col_user,
     )
 
     # DCG over IDCG is the normalized DCG

--- a/recommenders/evaluation/python_evaluation.py
+++ b/recommenders/evaluation/python_evaluation.py
@@ -554,7 +554,7 @@ def ndcg_at_k(
         float: nDCG at k (min=0, max=1).
     """
 
-    df_hit, df_hit_count, n_users = merge_ranking_true_pred(
+    df_hit, _, _ = merge_ranking_true_pred(
         rating_true=rating_true,
         rating_pred=rating_pred,
         col_user=col_user,
@@ -589,20 +589,20 @@ def ndcg_at_k(
     else:
         raise ValueError("discfun_type must be one of 'loge', 'log2'")
 
-    # calculate actual discounted gain for each record
+    # Calculate the actual discounted gain for each record
     df_dcg["dcg"] = df_dcg["rel"] / discfun(1 + df_dcg["rank"])
 
-    # calculate ideal discounted gain for each record
+    # Calculate the ideal discounted gain for each record
     df_idcg = df_dcg.sort_values([col_user, col_rating], ascending=False)
     df_idcg["irank"] = df_idcg.groupby(col_user, as_index=False, sort=False)[
         col_rating
     ].rank("first", ascending=False)
     df_idcg["idcg"] = df_idcg["rel"] / discfun(1 + df_idcg["irank"])
 
-    # calculate actual DCG for each user
+    # Calculate the actual DCG for each user
     df_user = df_dcg.groupby(col_user, as_index=False, sort=False).agg({"dcg": "sum"})
 
-    # calculate ideal DCG for each user
+    # Calculate the ideal DCG for each user
     df_user = df_user.merge(
         df_idcg.groupby(col_user, as_index=False, sort=False)
         .head(k)

--- a/recommenders/evaluation/python_evaluation.py
+++ b/recommenders/evaluation/python_evaluation.py
@@ -570,7 +570,7 @@ def ndcg_at_k(
         return 0.0
 
     df_dcg = df_hit.merge(rating_pred, on=[col_user, col_item]).merge(
-        rating_true, on=[col_user, col_item], how="outer"
+        rating_true, on=[col_user, col_item], how="outer", suffixes=("_left", None)
     )
 
     if score_type == "binary":

--- a/tests/unit/recommenders/evaluation/test_python_evaluation.py
+++ b/tests/unit/recommenders/evaluation/test_python_evaluation.py
@@ -178,26 +178,20 @@ def test_python_mae(rating_true, rating_pred):
 
 
 def test_python_rsquared(rating_true, rating_pred):
-    assert (
-        rsquared(
-            rating_true=rating_true,
-            rating_pred=rating_true,
-            col_prediction=DEFAULT_RATING_COL,
-        )
-        == pytest.approx(1.0, TOL)
-    )
+    assert rsquared(
+        rating_true=rating_true,
+        rating_pred=rating_true,
+        col_prediction=DEFAULT_RATING_COL,
+    ) == pytest.approx(1.0, TOL)
     assert rsquared(rating_true, rating_pred) == pytest.approx(-31.699029, TOL)
 
 
 def test_python_exp_var(rating_true, rating_pred):
-    assert (
-        exp_var(
-            rating_true=rating_true,
-            rating_pred=rating_true,
-            col_prediction=DEFAULT_RATING_COL,
-        )
-        == pytest.approx(1.0, TOL)
-    )
+    assert exp_var(
+        rating_true=rating_true,
+        rating_pred=rating_true,
+        col_prediction=DEFAULT_RATING_COL,
+    ) == pytest.approx(1.0, TOL)
     assert exp_var(rating_true, rating_pred) == pytest.approx(-6.4466, TOL)
 
 
@@ -211,16 +205,16 @@ def test_get_top_k_items(rating_true):
     top_3_user_true = pd.Series([1, 1, 1, 2, 2, 2, 3, 3, 3])
     top_3_rating_true = pd.Series([5, 4, 3, 5, 5, 3, 5, 5, 5])
     top_3_rank_true = pd.Series([1, 2, 3, 1, 2, 3, 1, 2, 3])
-    assert(top_3_items_df[DEFAULT_USER_COL].equals(top_3_user_true))
-    assert(top_3_items_df[DEFAULT_RATING_COL].equals(top_3_rating_true))
-    assert(top_3_items_df['rank'].equals(top_3_rank_true))
-    assert(top_3_items_df[DEFAULT_ITEM_COL][:3].equals(pd.Series([1, 2, 3])))
+    assert top_3_items_df[DEFAULT_USER_COL].equals(top_3_user_true)
+    assert top_3_items_df[DEFAULT_RATING_COL].equals(top_3_rating_true)
+    assert top_3_items_df["rank"].equals(top_3_rank_true)
+    assert top_3_items_df[DEFAULT_ITEM_COL][:3].equals(pd.Series([1, 2, 3]))
     # First two itemIDs of user 2. The scores are both 5, so any order is OK.
-    assert(set(top_3_items_df[DEFAULT_ITEM_COL][3:5]) == set([1, 4]))
+    assert set(top_3_items_df[DEFAULT_ITEM_COL][3:5]) == set([1, 4])
     # Third itemID of user 2. Both item 5 and 6 have a score of 3, so either one is OK.
-    assert(top_3_items_df[DEFAULT_ITEM_COL][5] in [5, 6])
+    assert top_3_items_df[DEFAULT_ITEM_COL][5] in [5, 6]
     # All itemIDs of user 3. All three items have a score of 5, so any order is OK.
-    assert(set(top_3_items_df[DEFAULT_ITEM_COL][6:]) == set([2, 5, 6]))
+    assert set(top_3_items_df[DEFAULT_ITEM_COL][6:]) == set([2, 5, 6])
 
 
 # Test get_top_k_items() when k is larger than the number of available items
@@ -234,33 +228,30 @@ def test_get_top_k_items_largek(rating_true):
     top_6_user_true = pd.Series([1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3])
     top_6_rating_true = pd.Series([5, 4, 3, 5, 5, 3, 3, 1, 5, 5, 5, 4, 4, 3])
     top_6_rank_true = pd.Series([1, 2, 3, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 6])
-    assert(top_6_items_df[DEFAULT_USER_COL].equals(top_6_user_true))
-    assert(top_6_items_df[DEFAULT_RATING_COL].equals(top_6_rating_true))
-    assert(top_6_items_df['rank'].equals(top_6_rank_true))
-    assert(top_6_items_df[DEFAULT_ITEM_COL][:3].equals(pd.Series([1, 2, 3])))
+    assert top_6_items_df[DEFAULT_USER_COL].equals(top_6_user_true)
+    assert top_6_items_df[DEFAULT_RATING_COL].equals(top_6_rating_true)
+    assert top_6_items_df["rank"].equals(top_6_rank_true)
+    assert top_6_items_df[DEFAULT_ITEM_COL][:3].equals(pd.Series([1, 2, 3]))
     # First two itemIDs of user 2. The scores are both 5, so any order is OK.
-    assert(set(top_6_items_df[DEFAULT_ITEM_COL][3:5]) == set([1, 4]))
+    assert set(top_6_items_df[DEFAULT_ITEM_COL][3:5]) == set([1, 4])
     # Third and fourth itemID of user 2. The scores are both 3, so any order is OK.
-    assert(set(top_6_items_df[DEFAULT_ITEM_COL][5:7]) == set([5, 6]))
-    assert(top_6_items_df[DEFAULT_ITEM_COL][7] == 7)
+    assert set(top_6_items_df[DEFAULT_ITEM_COL][5:7]) == set([5, 6])
+    assert top_6_items_df[DEFAULT_ITEM_COL][7] == 7
     # First three itemIDs of user 3. The scores are both 5, so any order is OK.
-    assert(set(top_6_items_df[DEFAULT_ITEM_COL][8:11]) == set([2, 5, 6]))
+    assert set(top_6_items_df[DEFAULT_ITEM_COL][8:11]) == set([2, 5, 6])
     # Fourth and fifth itemID of user 3. The scores are both 4, so any order is OK.
-    assert(set(top_6_items_df[DEFAULT_ITEM_COL][11:13]) == set([8, 9]))
+    assert set(top_6_items_df[DEFAULT_ITEM_COL][11:13]) == set([8, 9])
     # Sixth itemID of user 3. Item 10,11,12 have a score of 3, so either one is OK.
-    assert(top_6_items_df[DEFAULT_ITEM_COL][13] in [10, 11, 12])
+    assert top_6_items_df[DEFAULT_ITEM_COL][13] in [10, 11, 12]
 
 
 def test_python_ndcg_at_k(rating_true, rating_pred, rating_nohit):
-    assert (
-        ndcg_at_k(
-            rating_true=rating_true,
-            rating_pred=rating_true,
-            col_prediction=DEFAULT_RATING_COL,
-            k=10,
-        )
-        == pytest.approx(1.0, TOL)
-    )
+    assert ndcg_at_k(
+        rating_true=rating_true,
+        rating_pred=rating_true,
+        col_prediction=DEFAULT_RATING_COL,
+        k=10,
+    ) == pytest.approx(1.0, TOL)
     assert ndcg_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert ndcg_at_k(rating_true, rating_pred, k=10) == pytest.approx(0.38172, TOL)
 
@@ -280,7 +271,9 @@ def test_python_ndcg_at_k(rating_true, rating_pred, rating_nohit):
             DEFAULT_PREDICTION_COL: np.asarray([6, 5, 4, 3, 2, 1]),
         }
     )
-    assert ndcg_at_k(df_true, df_pred, k=6, score_type="raw", discfun_type="log2") == pytest.approx(0.785, TOL)
+    assert ndcg_at_k(
+        df_true, df_pred, k=6, score_type="raw", discfun_type="log2"
+    ) == pytest.approx(0.785, TOL)
 
 
 def test_python_map_at_k(rating_true, rating_pred, rating_nohit):
@@ -360,59 +353,44 @@ def test_python_precision(rating_true, rating_pred, rating_nohit):
 
 
 def test_python_recall(rating_true, rating_pred, rating_nohit):
-    assert (
-        recall_at_k(
-            rating_true=rating_true,
-            rating_pred=rating_true,
-            col_prediction=DEFAULT_RATING_COL,
-            k=10,
-        )
-        == pytest.approx(1, TOL)
-    )
+    assert recall_at_k(
+        rating_true=rating_true,
+        rating_pred=rating_true,
+        col_prediction=DEFAULT_RATING_COL,
+        k=10,
+    ) == pytest.approx(1, TOL)
     assert recall_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert recall_at_k(rating_true, rating_pred, k=10) == pytest.approx(0.37777, TOL)
 
 
 def test_python_auc(rating_true_binary, rating_pred_binary):
-    assert (
-        auc(
-            rating_true=rating_true_binary,
-            rating_pred=rating_true_binary,
-            col_prediction=DEFAULT_RATING_COL,
-        )
-        == pytest.approx(1.0, TOL)
-    )
+    assert auc(
+        rating_true=rating_true_binary,
+        rating_pred=rating_true_binary,
+        col_prediction=DEFAULT_RATING_COL,
+    ) == pytest.approx(1.0, TOL)
 
-    assert (
-        auc(
-            rating_true=rating_true_binary,
-            rating_pred=rating_pred_binary,
-            col_rating=DEFAULT_RATING_COL,
-            col_prediction=DEFAULT_PREDICTION_COL,
-        )
-        == pytest.approx(0.75, TOL)
-    )
+    assert auc(
+        rating_true=rating_true_binary,
+        rating_pred=rating_pred_binary,
+        col_rating=DEFAULT_RATING_COL,
+        col_prediction=DEFAULT_PREDICTION_COL,
+    ) == pytest.approx(0.75, TOL)
 
 
 def test_python_logloss(rating_true_binary, rating_pred_binary):
-    assert (
-        logloss(
-            rating_true=rating_true_binary,
-            rating_pred=rating_true_binary,
-            col_prediction=DEFAULT_RATING_COL,
-        )
-        == pytest.approx(0, TOL)
-    )
+    assert logloss(
+        rating_true=rating_true_binary,
+        rating_pred=rating_true_binary,
+        col_prediction=DEFAULT_RATING_COL,
+    ) == pytest.approx(0, TOL)
 
-    assert (
-        logloss(
-            rating_true=rating_true_binary,
-            rating_pred=rating_pred_binary,
-            col_rating=DEFAULT_RATING_COL,
-            col_prediction=DEFAULT_PREDICTION_COL,
-        )
-        == pytest.approx(0.7835, TOL)
-    )
+    assert logloss(
+        rating_true=rating_true_binary,
+        rating_pred=rating_pred_binary,
+        col_rating=DEFAULT_RATING_COL,
+        col_prediction=DEFAULT_PREDICTION_COL,
+    ) == pytest.approx(0.7835, TOL)
 
 
 def test_python_errors(rating_true, rating_pred):

--- a/tests/unit/recommenders/evaluation/test_python_evaluation.py
+++ b/tests/unit/recommenders/evaluation/test_python_evaluation.py
@@ -264,6 +264,24 @@ def test_python_ndcg_at_k(rating_true, rating_pred, rating_nohit):
     assert ndcg_at_k(rating_true, rating_nohit, k=10) == 0.0
     assert ndcg_at_k(rating_true, rating_pred, k=10) == pytest.approx(0.38172, TOL)
 
+    # Test raw relevance score and log2 discounting factor using wiki example
+    # See https://en.wikipedia.org/wiki/Discounted_cumulative_gain
+    df_true = pd.DataFrame(
+        {
+            DEFAULT_USER_COL: np.full(8, 0, dtype=int),
+            DEFAULT_ITEM_COL: np.arange(8),
+            DEFAULT_RATING_COL: np.asarray([3, 2, 3, 0, 1, 2, 3, 2]),
+        }
+    )
+    df_pred = pd.DataFrame(
+        {
+            DEFAULT_USER_COL: np.full(6, 0, dtype=int),
+            DEFAULT_ITEM_COL: np.arange(6),
+            DEFAULT_PREDICTION_COL: np.asarray([6, 5, 4, 3, 2, 1]),
+        }
+    )
+    assert ndcg_at_k(df_true, df_pred, k=6, score_type="raw", discfun_type="log2") == pytest.approx(0.785, TOL)
+
 
 def test_python_map_at_k(rating_true, rating_pred, rating_nohit):
     assert (

--- a/tests/unit/recommenders/evaluation/test_python_evaluation_time_performance.py
+++ b/tests/unit/recommenders/evaluation/test_python_evaluation_time_performance.py
@@ -185,7 +185,7 @@ def test_python_ndcg_at_k(rating_true, rating_pred):
             col_prediction=DEFAULT_PREDICTION_COL,
             k=10,
         )
-    assert t.interval < 21.55627936 * (1 + TOL)
+    assert t.interval < 39.03877957 * (1 + TOL)
 
 
 def test_python_map_at_k(rating_true, rating_pred):


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Implemented a generalized version of NDCG. The function now supports three types of relevance scores: binary, raw, and exponential. It also supports two types of discount functions: natural log, and log2. 

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue: https://github.com/microsoft/recommenders/issues/1749. The example is added as a new test case for raw relevance scores.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [x] This PR is being made to `staging branch` and not to `main branch`.
