### PR TITLE
Fix deprecation of node12 actions

### DIFF
--- a/.github/actions/azureml-test/action.yml
+++ b/.github/actions/azureml-test/action.yml
@@ -69,7 +69,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with: 
         python-version: "3.8"
     - name: Install azureml-core and azure-cli on a GitHub hosted server

--- a/.github/actions/azureml-test/action.yml
+++ b/.github/actions/azureml-test/action.yml
@@ -69,7 +69,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with: 
         python-version: "3.8"
     - name: Install azureml-core and azure-cli on a GitHub hosted server

--- a/.github/workflows/azureml-cpu-nightly.yml
+++ b/.github/workflows/azureml-cpu-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get test group names
         id: get_test_groups
         uses: ./.github/actions/get-test-groups
@@ -71,7 +71,7 @@ jobs:
         test-group:  ${{ fromJSON(needs.get-test-groups.outputs.test_groups) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Execute tests
         uses: ./.github/actions/azureml-test
         id: execute_tests

--- a/.github/workflows/azureml-gpu-nightly.yml
+++ b/.github/workflows/azureml-gpu-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get test group names
         id: get_test_groups
         uses: ./.github/actions/get-test-groups
@@ -71,7 +71,7 @@ jobs:
         test-group:  ${{ fromJSON(needs.get-test-groups.outputs.test_groups) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Execute tests
         uses: ./.github/actions/azureml-test
         id: execute_tests

--- a/.github/workflows/azureml-release-pipeline.yml
+++ b/.github/workflows/azureml-release-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with: 
           python-version: "3.8"
       - name: Install wheel package

--- a/.github/workflows/azureml-release-pipeline.yml
+++ b/.github/workflows/azureml-release-pipeline.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [unit-test-workflow, cpu-nightly-workflow, gpu-nightly-workflow, spark-nightly-workflow]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v2
         with: 

--- a/.github/workflows/azureml-release-pipeline.yml
+++ b/.github/workflows/azureml-release-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with: 
           python-version: "3.8"
       - name: Install wheel package

--- a/.github/workflows/azureml-spark-nightly.yml
+++ b/.github/workflows/azureml-spark-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get test group names
         id: get_test_groups
         uses: ./.github/actions/get-test-groups
@@ -71,7 +71,7 @@ jobs:
         test-group:  ${{ fromJSON(needs.get-test-groups.outputs.test_groups) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Execute tests
         uses: ./.github/actions/azureml-test
         id: execute_tests

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Get test group names
         id: get_test_groups
         uses: ./.github/actions/get-test-groups
@@ -58,7 +58,7 @@ jobs:
         test-group:  ${{ fromJSON(needs.get-test-groups.outputs.test_groups) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Execute tests
         uses: ./.github/actions/azureml-test
         id: execute_tests

--- a/.github/workflows/pypi-test-publish.yml
+++ b/.github/workflows/pypi-test-publish.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/pypi-test-publish.yml
+++ b/.github/workflows/pypi-test-publish.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/sarplus.yml
+++ b/.github/workflows/sarplus.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -124,7 +124,7 @@ jobs:
             hadoop-version: "3.3.1"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Test
         run: |


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
We are getting some warnings that we need to update the node12 to node16 and that affects some commands in GitHub actions. See https://github.com/microsoft/recommenders/actions/runs/3442907860

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2
```
hopefully nothing breaks :-)

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
