### PR TITLE
Add scrapbook to the base deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ install_requires = [
     "cornac>=1.1.2,<2",
     "retrying>=1.3.3",
     "pandera[strategies]>=0.6.5",  # For generating fake datasets
-    "scikit-surprise>=1.0.6"
+    "scikit-surprise>=1.0.6",
+    "scrapbook>=0.5.0,<1.0.0",
 ]
 
 # shared dependencies
@@ -60,7 +61,6 @@ extras_require = {
         "jupyter>=1,<2",
         "locust>=1,<2",
         "papermill>=2.1.2,<3",
-        "scrapbook>=0.5.0,<1.0.0",
     ],
     "gpu": [
         "nvidia-ml-py3>=7.352.0",


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
The reasoning for this small change:

scrapbook is in all notebooks, so I wanted to show a simple example of running `pip install recommenders` and then run the SAR notebook, but I realised that that dep was missing.

What do you guys think about this change?

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
