### PR TITLE
Fix pyspark test

### DIFF
--- a/.github/actions/azureml-test/action.yml
+++ b/.github/actions/azureml-test/action.yml
@@ -109,11 +109,11 @@ runs:
       shell: bash
       if: contains(inputs.TEST_GROUP, 'spark')
       run: >-
-          python tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py --clustername ${{inputs.CPU_CLUSTER_NAME}} \
-          --subid ${{inputs.AZUREML_TEST_SUBID}} --reponame "recommenders" --branch ${{ github.ref }} \
-          --rg ${{inputs.RG}} --wsname ${{inputs.WS}} --expname ${{inputs.EXP_NAME}}_${{inputs.TEST_GROUP}} \
-          --testlogs ${{inputs.TEST_LOGS_PATH}} --add_spark_dependencies --testkind ${{inputs.TEST_KIND}} \
-          --conda_pkg_python ${{inputs.PYTHON_VERSION}} --testgroup ${{inputs.TEST_GROUP}} \
+          python tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py --clustername ${{inputs.CPU_CLUSTER_NAME}}
+          --subid ${{inputs.AZUREML_TEST_SUBID}} --reponame "recommenders" --branch ${{ github.ref }}
+          --rg ${{inputs.RG}} --wsname ${{inputs.WS}} --expname ${{inputs.EXP_NAME}}_${{inputs.TEST_GROUP}}
+          --testlogs ${{inputs.TEST_LOGS_PATH}} --add_spark_dependencies --testkind ${{inputs.TEST_KIND}}
+          --conda_pkg_python ${{inputs.PYTHON_VERSION}} --testgroup ${{inputs.TEST_GROUP}}
           --disable-warnings
     - name: Print test logs
       shell: bash

--- a/.github/actions/azureml-test/action.yml
+++ b/.github/actions/azureml-test/action.yml
@@ -48,12 +48,12 @@ inputs:
   RG:
     required: false
     type: string
-    default: "recommenders_project_resources"  
+    default: "recommenders_project_resources"
   # AzureML workspace name
   WS:
     required: false
     type: string
-    default: "azureml-test-workspace"  
+    default: "azureml-test-workspace"
   # test logs path
   TEST_LOGS_PATH:
     required: false
@@ -70,7 +70,7 @@ runs:
   steps:
     - name: Setup python
       uses: actions/setup-python@v4
-      with: 
+      with:
         python-version: "3.8"
     - name: Install azureml-core and azure-cli on a GitHub hosted server
       shell: bash
@@ -92,9 +92,9 @@ runs:
           python tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py --clustername ${{inputs.CPU_CLUSTER_NAME}}
           --subid ${{inputs.AZUREML_TEST_SUBID}} --reponame "recommenders" --branch ${{ github.ref }}
           --rg ${{inputs.RG}} --wsname ${{inputs.WS}} --expname ${{inputs.EXP_NAME}}_${{inputs.TEST_GROUP}}
-          --testlogs ${{inputs.TEST_LOGS_PATH}} --testkind ${{inputs.TEST_KIND}} 
+          --testlogs ${{inputs.TEST_LOGS_PATH}} --testkind ${{inputs.TEST_KIND}}
           --conda_pkg_python ${{inputs.PYTHON_VERSION}} --testgroup ${{inputs.TEST_GROUP}}
-          --disable-warnings 
+          --disable-warnings
     - name: Submit GPU tests to AzureML
       shell: bash
       if: contains(inputs.TEST_GROUP, 'gpu')
@@ -108,18 +108,7 @@ runs:
     - name: Submit PySpark tests to AzureML
       shell: bash
       if: contains(inputs.TEST_GROUP, 'spark')
-      run: |
-          echo $JAVA_HOME
-          echo $PYSPARK_PYTHON
-          echo $PYSPARK_DRIVER_PYTHON
-          export PYSPARK_PYTHON=$Python_ROOT_DIR/bin/python
-          export PYSPARK_DRIVER_PYTHON=$Python_ROOT_DIR/bin/python
-          echo $PYSPARK_PYTHON
-          echo $PYSPARK_DRIVER_PYTHON
-          sudo apt install openjdk-17-jre -q
-          JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-          echo $JAVA_HOME
-          env
+      run: >-
           python tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py --clustername ${{inputs.CPU_CLUSTER_NAME}} \
           --subid ${{inputs.AZUREML_TEST_SUBID}} --reponame "recommenders" --branch ${{ github.ref }} \
           --rg ${{inputs.RG}} --wsname ${{inputs.WS}} --expname ${{inputs.EXP_NAME}}_${{inputs.TEST_GROUP}} \

--- a/recommenders/utils/spark_utils.py
+++ b/recommenders/utils/spark_utils.py
@@ -65,7 +65,7 @@ def start_or_get_spark(
     if config is None or "spark.driver.memory" not in config:
         spark_opts.append('config("spark.driver.memory", "{}")'.format(memory))
 
-    # Set extra memory
+    # Set larger stack size
     spark_opts.append('config("spark.executor.extraJavaOptions", "-Xss4m")')
     spark_opts.append('config("spark.driver.extraJavaOptions", "-Xss4m")')
 

--- a/recommenders/utils/spark_utils.py
+++ b/recommenders/utils/spark_utils.py
@@ -30,7 +30,7 @@ def start_or_get_spark(
     Args:
         app_name (str): set name of the application
         url (str): URL for spark master
-        memory (str): size of memory for spark driver
+        memory (str): size of memory for spark driver. This will be ignored if spark.driver.memory is set in config.
         config (dict): dictionary of configuration options
         packages (list): list of packages to install
         jars (list): list of jar files to add
@@ -64,6 +64,10 @@ def start_or_get_spark(
 
     if config is None or "spark.driver.memory" not in config:
         spark_opts.append('config("spark.driver.memory", "{}")'.format(memory))
+
+    # Set extra memory
+    spark_opts.append('config("spark.executor.extraJavaOptions", "-Xss4m")')
+    spark_opts.append('config("spark.driver.extraJavaOptions", "-Xss4m")')
 
     spark_opts.append("getOrCreate()")
     return eval(".".join(spark_opts))

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -209,15 +209,6 @@ def create_run_config(
         conda_dep.add_channel("conda-forge")
         conda_dep.add_conda_package(conda_pkg_jdk)
         conda_dep.add_pip_package("recommenders[dev,examples,spark]")
-        # run_azuremlcompute.environment_variables = {
-        #     "PYSPARK_PYTHON": "python",
-        #     "PYSPARK_DRIVER_PYTHON": "python",
-        #     "SPARK_HOME": "",
-        # }
-        # env = run_azuremlcompute.environment
-        # env.environment_variables["PYSPARK_PYTHON"] = env.python.interpreter_path
-        # env.environment_variables["PYSPARK_DRIVER_PYTHON"] = env.python.interpreter_path
-        # env.environment_variables["SPARK_HOME"] = ""
     else:
         conda_dep.add_pip_package("recommenders[dev,examples]")
 
@@ -272,7 +263,6 @@ def submit_experiment_to_azureml(
         script=test,
         run_config=run_config,
         arguments=arguments,
-        # docker_runtime_config=dc
     )
     run = experiment.submit(script_run_config)
     # waits only for configuration to complete

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -209,10 +209,11 @@ def create_run_config(
         conda_dep.add_channel("conda-forge")
         conda_dep.add_conda_package(conda_pkg_jdk)
         conda_dep.add_pip_package("recommenders[dev,examples,spark]")
-        # run_azuremlcompute.environment_variables = {
-        #     "PYSPARK_PYTHON": "$Python_ROOT_DIR/bin/python",
-        #     "PYSPARK_DRIVER_PYTHON": "$Python_ROOT_DIR/bin/python",
-        # }
+        run_azuremlcompute.environment_variables = {
+            "PYSPARK_PYTHON": "$Python_ROOT_DIR/bin/python",
+            "PYSPARK_DRIVER_PYTHON": "$Python_ROOT_DIR/bin/python",
+            "SPARK_HOME": "",
+        }
     else:
         conda_dep.add_pip_package("recommenders[dev,examples]")
 

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -209,7 +209,10 @@ def create_run_config(
         conda_dep.add_channel("conda-forge")
         conda_dep.add_conda_package(conda_pkg_jdk)
         conda_dep.add_pip_package("recommenders[dev,examples,spark]")
-        run_azuremlcompute.environment.environment_variables["SPARK_HOME"] = ""
+        env = run_azuremlcompute.environment
+        env.environment_variables["PYSPARK_PYTHON"] = env.python.interpreter_path
+        env.environment_variables["PYSPARK_DRIVER_PYTHON"] = env.python.interpreter_path
+        env.environment_variables["SPARK_HOME"] = ""
     else:
         conda_dep.add_pip_package("recommenders[dev,examples]")
 

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -273,7 +273,7 @@ def submit_experiment_to_azureml(
         run_config=run_config,
         arguments=arguments,
         # FIXME
-        command='export PYSPARK_PYTHON=$(which python) && export PYSPARK_DRIVER_PYTHON=$(which python) && unset SPARK_HOME && python {test}'.split(),
+        command=f'export PYSPARK_PYTHON=$(which python) && export PYSPARK_DRIVER_PYTHON=$(which python) && unset SPARK_HOME && python {test}'.split(),
         # docker_runtime_config=dc
     )
     run = experiment.submit(script_run_config)

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -209,11 +209,11 @@ def create_run_config(
         conda_dep.add_channel("conda-forge")
         conda_dep.add_conda_package(conda_pkg_jdk)
         conda_dep.add_pip_package("recommenders[dev,examples,spark]")
-        run_azuremlcompute.environment_variables = {
-            "PYSPARK_PYTHON": "python",
-            "PYSPARK_DRIVER_PYTHON": "python",
-            "SPARK_HOME": "",
-        }
+        # run_azuremlcompute.environment_variables = {
+        #     "PYSPARK_PYTHON": "python",
+        #     "PYSPARK_DRIVER_PYTHON": "python",
+        #     "SPARK_HOME": "",
+        # }
         # env = run_azuremlcompute.environment
         # env.environment_variables["PYSPARK_PYTHON"] = env.python.interpreter_path
         # env.environment_variables["PYSPARK_DRIVER_PYTHON"] = env.python.interpreter_path
@@ -269,9 +269,11 @@ def submit_experiment_to_azureml(
 
     script_run_config = ScriptRunConfig(
         source_directory=".",
-        script=test,
+        # script=test,
         run_config=run_config,
         arguments=arguments,
+        # FIXME
+        command='export PYSPARK_PYTHON=$(which python) && export PYSPARK_DRIVER_PYTHON=$(which python) && unset SPARK_HOME && python {test}'.split(),
         # docker_runtime_config=dc
     )
     run = experiment.submit(script_run_config)

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -271,9 +271,9 @@ def submit_experiment_to_azureml(
         source_directory=".",
         # script=test,
         run_config=run_config,
-        arguments=arguments,
+        # arguments=arguments,
         # FIXME
-        command=f'export PYSPARK_PYTHON=$(which python) && export PYSPARK_DRIVER_PYTHON=$(which python) && unset SPARK_HOME && python {test}'.split(),
+        command=f'export PYSPARK_PYTHON=$(which python) && export PYSPARK_DRIVER_PYTHON=$(which python) && unset SPARK_HOME && python {test}'.split() + arguments,
         # docker_runtime_config=dc
     )
     run = experiment.submit(script_run_config)

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -209,11 +209,7 @@ def create_run_config(
         conda_dep.add_channel("conda-forge")
         conda_dep.add_conda_package(conda_pkg_jdk)
         conda_dep.add_pip_package("recommenders[dev,examples,spark]")
-        run_azuremlcompute.environment_variables = {
-            "PYSPARK_PYTHON": "$Python_ROOT_DIR/bin/python",
-            "PYSPARK_DRIVER_PYTHON": "$Python_ROOT_DIR/bin/python",
-            "SPARK_HOME": "",
-        }
+        run_azuremlcompute.environment.environment_variables["SPARK_HOME"] = ""
     else:
         conda_dep.add_pip_package("recommenders[dev,examples]")
 

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -209,10 +209,15 @@ def create_run_config(
         conda_dep.add_channel("conda-forge")
         conda_dep.add_conda_package(conda_pkg_jdk)
         conda_dep.add_pip_package("recommenders[dev,examples,spark]")
-        env = run_azuremlcompute.environment
-        env.environment_variables["PYSPARK_PYTHON"] = env.python.interpreter_path
-        env.environment_variables["PYSPARK_DRIVER_PYTHON"] = env.python.interpreter_path
-        env.environment_variables["SPARK_HOME"] = ""
+        run_azuremlcompute.environment_variables = {
+            "PYSPARK_PYTHON": "python",
+            "PYSPARK_DRIVER_PYTHON": "python",
+            "SPARK_HOME": "",
+        }
+        # env = run_azuremlcompute.environment
+        # env.environment_variables["PYSPARK_PYTHON"] = env.python.interpreter_path
+        # env.environment_variables["PYSPARK_DRIVER_PYTHON"] = env.python.interpreter_path
+        # env.environment_variables["SPARK_HOME"] = ""
     else:
         conda_dep.add_pip_package("recommenders[dev,examples]")
 

--- a/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
+++ b/tests/ci/azureml_tests/submit_groupwise_azureml_pytest.py
@@ -269,11 +269,9 @@ def submit_experiment_to_azureml(
 
     script_run_config = ScriptRunConfig(
         source_directory=".",
-        # script=test,
+        script=test,
         run_config=run_config,
-        # arguments=arguments,
-        # FIXME
-        command=f'export PYSPARK_PYTHON=$(which python) && export PYSPARK_DRIVER_PYTHON=$(which python) && unset SPARK_HOME && python {test}'.split() + arguments,
+        arguments=arguments,
         # docker_runtime_config=dc
     )
     run = experiment.submit(script_run_config)
@@ -487,9 +485,13 @@ if __name__ == "__main__":
     )
 
     # add helpful information to experiment on Azure
+    run.tag("Python", args.conda_pkg_python)
     run.tag("RepoName", args.reponame)
     run.tag("Branch", args.branch)
     run.tag("PR", args.pr)
+    run.tag("script", args.test)
+    run.tag("testgroup", args.testgroup)
+    run.tag("testkind", args.testkind)
 
     # download logs file from AzureML
     run.download_file(name="test_logs", output_file_path=args.testlogs)

--- a/tests/integration/examples/test_notebooks_pyspark.py
+++ b/tests/integration/examples/test_notebooks_pyspark.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import os
 import sys
 import pytest
 
@@ -79,6 +80,11 @@ def test_mmlspark_lightgbm_criteo_integration(notebooks, output_notebook, kernel
 )
 def test_benchmark_movielens_pyspark(notebooks, output_notebook, kernel_name, size, algos, expected_values_ndcg):
     notebook_path = notebooks["benchmark_movielens"]
+
+    os.environ["PYSPARK_PYTHON"] = sys.executable
+    os.environ["PYSPARK_DRIVER_PYTHON"] = sys.executable
+    os.environ.pop("SPARK_HOME", None)
+
     pm.execute_notebook(
         notebook_path,
         output_notebook,


### PR DESCRIPTION
### Description
Env vars necessary to use PySpark doesn't set properly when using AzureML for testing.
This PR sets the env vars. Additionally, increase the stack size in driver and executors to avoid StackOverflowError.

### Related Issues
#1898 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
