### PR TITLE
Reduce double nightly tests

### DIFF
--- a/.github/workflows/azureml-cpu-nightly.yml
+++ b/.github/workflows/azureml-cpu-nightly.yml
@@ -18,12 +18,11 @@ on:
     # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
   
   push:
-    # because we can't schedule runs for non-main branches,
+    # Because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging]
     paths:
-      # Unit tests will be run only when there are changes in the
-      # unit tests related code including:
+      # Tests will be run only when there are changes in the code:
       - examples/**
       - '!examples/**/*.md'
       - recommenders/**

--- a/.github/workflows/azureml-cpu-nightly.yml
+++ b/.github/workflows/azureml-cpu-nightly.yml
@@ -21,10 +21,6 @@ on:
     # because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging]
-
-  pull_request:
-    branches:
-      - 'main'
     paths:
       # Unit tests will be run only when there are changes in the
       # unit tests related code including:

--- a/.github/workflows/azureml-cpu-nightly.yml
+++ b/.github/workflows/azureml-cpu-nightly.yml
@@ -25,9 +25,13 @@ on:
       # Unit tests will be run only when there are changes in the
       # unit tests related code including:
       - examples/**
+      - '!examples/**/*.md'
       - recommenders/**
+      - '!recommenders/**/*.md'
       - tests/**
+      - '!tests/**/*.md'
       - setup.py
+
 
   # Enable manual trigger
   workflow_dispatch:

--- a/.github/workflows/azureml-gpu-nightly.yml
+++ b/.github/workflows/azureml-gpu-nightly.yml
@@ -18,12 +18,11 @@ on:
     # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
   
   push:
-    # because we can't schedule runs for non-main branches,
+    # Because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging]
     paths:
-      # Unit tests will be run only when there are changes in the
-      # unit tests related code including:
+      # Tests will be run only when there are changes in the code:
       - examples/**
       - '!examples/**/*.md'
       - recommenders/**

--- a/.github/workflows/azureml-gpu-nightly.yml
+++ b/.github/workflows/azureml-gpu-nightly.yml
@@ -21,10 +21,6 @@ on:
     # because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging]
-
-  pull_request:
-    branches:
-      - 'main'
     paths:
       # Unit tests will be run only when there are changes in the
       # unit tests related code including:

--- a/.github/workflows/azureml-gpu-nightly.yml
+++ b/.github/workflows/azureml-gpu-nightly.yml
@@ -25,9 +25,13 @@ on:
       # Unit tests will be run only when there are changes in the
       # unit tests related code including:
       - examples/**
+      - '!examples/**/*.md'
       - recommenders/**
+      - '!recommenders/**/*.md'
       - tests/**
+      - '!tests/**/*.md'
       - setup.py
+
 
   # Enable manual trigger
   workflow_dispatch:

--- a/.github/workflows/azureml-spark-nightly.yml
+++ b/.github/workflows/azureml-spark-nightly.yml
@@ -25,8 +25,11 @@ on:
       # Unit tests will be run only when there are changes in the
       # unit tests related code including:
       - examples/**
+      - '!examples/**/*.md'
       - recommenders/**
+      - '!recommenders/**/*.md'
       - tests/**
+      - '!tests/**/*.md'
       - setup.py
 
   # Enable manual trigger

--- a/.github/workflows/azureml-spark-nightly.yml
+++ b/.github/workflows/azureml-spark-nightly.yml
@@ -18,12 +18,11 @@ on:
     # cron works with default branch (main) only: # https://github.community/t/on-schedule-per-branch/17525/2
   
   push:
-    # because we can't schedule runs for non-main branches,
+    # Because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging]
     paths:
-      # Unit tests will be run only when there are changes in the
-      # unit tests related code including:
+      # Tests will be run only when there are changes in the code:
       - examples/**
       - '!examples/**/*.md'
       - recommenders/**

--- a/.github/workflows/azureml-spark-nightly.yml
+++ b/.github/workflows/azureml-spark-nightly.yml
@@ -21,10 +21,6 @@ on:
     # because we can't schedule runs for non-main branches,
     # to ensure we are running the build on the staging branch, we can add push policy for it
     branches: [staging]
-
-  pull_request:
-    branches:
-      - 'main'
     paths:
       # Unit tests will be run only when there are changes in the
       # unit tests related code including:

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -11,8 +11,7 @@ on:
       - 'staging'
       - 'main'
     paths:
-      # Tests will be run only when there are changes in the
-      # unit tests related code including:
+      # Tests will be run only when there are changes in the code:
       - examples/**
       - '!examples/**/*.md'
       - recommenders/**

--- a/.github/workflows/azureml-unit-tests.yml
+++ b/.github/workflows/azureml-unit-tests.yml
@@ -11,7 +11,7 @@ on:
       - 'staging'
       - 'main'
     paths:
-      # Unit tests will be run only when there are changes in the
+      # Tests will be run only when there are changes in the
       # unit tests related code including:
       - examples/**
       - '!examples/**/*.md'


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
I noticed that when there is a merge to staging and a PR to main, we are doing twice the nightly tests. They are the exact same tests so there is no need to have it twice.

![image](https://user-images.githubusercontent.com/3491412/228952069-24dc8721-17a8-4cad-9bd2-bafa539265e4.png)

By removing the trigger when there is a PR to main, we are still checking that the nightly have passed, because all new code that is merged to staging passes the nightly. 

In addition, every 5 days we are scheduling the nightly in main

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
