### PR TITLE
Remove deprecated setoutput in GitHub actions

### DIFF
--- a/.github/actions/azureml-test/action.yml
+++ b/.github/actions/azureml-test/action.yml
@@ -121,7 +121,7 @@ runs:
     - name: Get exit status
       shell: bash
       id: exit_status
-      run: echo ::set-output name=code::$(cat ${{inputs.PYTEST_EXIT_CODE}})
+      run: echo "code=$(cat ${{inputs.PYTEST_EXIT_CODE}})" >> $GITHUB_OUTPUT
     - name: Check Success/Failure
       if: ${{ steps.exit_status.outputs.code != 0 }}
       uses: actions/github-script@v3

--- a/.github/actions/get-test-groups/action.yml
+++ b/.github/actions/get-test-groups/action.yml
@@ -31,4 +31,4 @@ runs:
         else
           test_groups_str=$(python -c 'from tests.ci.azureml_tests.test_groups import unit_test_groups; print(list(unit_test_groups.keys()))')
         fi
-        echo ::set-output name=test_groups::$test_groups_str
+        echo "test_groups=$test_groups_str" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Deprecated command. More info https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Before:
https://github.com/microsoft/recommenders/actions/runs/4568440104

After:
https://github.com/microsoft/recommenders/actions/runs/4666074607


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### References
<!--- References would be helpful to understand the changes. -->
<!--- References can be books, links, etc. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [ ] This PR is being made to `staging branch` and not to `main branch`.
